### PR TITLE
Migrate to PureQL.CSharp.Model 0.1.0-preview.11.0.0 (spec 0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,67 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+## [0.1.0-preview.2.0.0] — 2026-05-28
+
+### Changed
+
+- Updated `PureQL.CSharp.Model` dependency from `0.1.0-preview.10.0.0` to
+  `0.1.0-preview.11.0.0`, which tracks PureQL specification
+  `0.1.0-preview.0.5.0`.
+- `Query.Where` is now `OneOf<BooleanReturning, BooleanArrayReturning>?`
+  — `RowsFromDatasets` dispatches on both arms via the new
+  `WhereExpressionBuilder.BuildPredicate` entry point.
+- `Query.OrderBy` is now `IEnumerable<OrderByItem>?` — `OrderByApplicator`
+  honours the per-item `SortDirection` (`Asc`/`Desc`), using
+  `OrderByDescending`/`ThenByDescending` for descending keys.
+- `Join.On` is now `OneOf<BooleanReturning, BooleanArrayReturning>` —
+  `JoinApplicator` routes the union through `BuildPredicate` so each\*
+  predicates work as join conditions.
+- `Field` union widened with the new `NullField` arm. `OrderByApplicator`
+  and `GroupByApplicator` accept it (treated as a constant-null sort /
+  group key).
+- `NumberReturning` extended with `Arithmetic`, `NumberAggregate`,
+  `Count`; `DateReturning` with `DateAggregate`; `StringReturning` with
+  `StringAggregate`; `TimeReturning` with `TimeAggregate`;
+  `DateTimeReturning` with `DateTimeAggregate`. The `WhereExpressionBuilder`
+  match arms are exhaustive; aggregates / single-value arithmetic in
+  row-by-row contexts raise `NotSupportedException` and are documented
+  in `EXECUTION_GAPS.md`.
+
+### Added
+
+- Execution support for the per-row predicate family
+  (`EachBooleanEquality`, `EachNumberEquality`, `EachStringEquality`,
+  `EachDateEquality`, `EachTimeEquality`, `EachDateTimeEquality`,
+  `EachUuidEquality`, `EachNumberComparison`, `EachStringComparison`,
+  `EachDateComparison`, `EachTimeComparison`, `EachDateTimeComparison`,
+  `EachAndOperator`, `EachOrOperator`, `EachNotOperator`) inside `Where`
+  and `Join.On` predicates. Supports both broadcast (`*Returning`
+  right-hand side) and zip (`*ArrayReturning` right-hand side) modes.
+- Execution support for the per-row arithmetic family
+  (`EachAdd`, `EachSubtract`, `EachMultiply`, `EachDivide`) and the
+  per-row date / time / datetime math operators
+  (`EachDateAddDays`, `EachDateDiffDays`, `EachTimeAddSeconds`,
+  `EachTimeDiffSeconds`, `EachDateTimeAddSeconds`,
+  `EachDateTimeDiffSeconds`) as operands of each\*-comparisons inside
+  filters. Numeric operations propagate `null` cleanly; division by
+  zero yields `null`.
+- `Query.Distinct` is honoured by a new `DistinctApplicator` that
+  deduplicates by ordinal-compared text cell values.
+- New test class `PureQLProjectionEachTests` covering each\* equality,
+  comparison, boolean composition, field-to-field comparison, empty
+  inputs, descending order, and `Distinct`.
+- `EXECUTION_GAPS.md` documenting the remaining executor gaps.
+- `CHANGELOG.md` (this file).
+
+### Removed
+
+- The `WhereExpressionBuilder.BuildBoolArrayReturningAsSingleBool` helper
+  is no longer reachable as a separate method — its responsibility has
+  been folded into `BuildBoolArrayPerRow`, which now handles all eight
+  arms of `BooleanArrayReturning`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,10 @@ All translation work is done by internal classes:
 - **`TableFromQuery`** — derives the virtual `ITable` schema from the query's SELECT expressions
 - **`RowsFromDatasets`** — orchestrates the full query pipeline: locates the source table dataset by `schema.table` path, then applies each clause in order
 - **`JoinApplicator`** — materializes joined datasets into lists and applies join conditions (supports INNER, LEFT, RIGHT, FULL)
-- **`WhereExpressionBuilder`** — compiles a `BooleanReturning` AST node from `PureQL.CSharp.Model` into a `Func<IRow, bool>` LINQ predicate
-- **`OrderByApplicator`** — applies `IEnumerable<Field>` ordering via LINQ `OrderBy`/`ThenBy`
+- **`WhereExpressionBuilder`** — compiles a `BooleanReturning` *or* per-row `BooleanArrayReturning` AST node from `PureQL.CSharp.Model` into a `Func<IRow, bool>` LINQ predicate (entry point: `BuildPredicate(OneOf<BooleanReturning, BooleanArrayReturning>)`). Implements the per-row `each*` family — `EachEquality`, `EachComparison`, `EachAnd`/`EachOr`/`EachNot`, plus per-row arithmetic (`EachArithmetic`, `EachDateAddDays`/`EachDateDiffDays`, `EachTimeAddSeconds`/`EachTimeDiffSeconds`, `EachDateTimeAddSeconds`/`EachDateTimeDiffSeconds`)
+- **`OrderByApplicator`** — applies `IEnumerable<OrderByItem>` ordering, honouring per-item `SortDirection` (`Asc`/`Desc`)
 - **`GroupByApplicator`** — applies GROUP BY fields and an optional HAVING predicate
+- **`DistinctApplicator`** — deduplicates the row set when `Query.Distinct == true`
 - **`CellValueExtractor`** — extracts typed .NET values from `ICell` for the seven supported column types: bool, date, datetime, double, string, time, uuid
 - **`ColumnsFromQuery`** — maps `SelectExpression` nodes to `IColumn` instances for the result schema
 
@@ -46,6 +47,8 @@ The library is **not AOT-compatible** (`IsAotCompatible = false`) because the qu
 **Publishing:** triggered by pushing a semver tag matching `*.*.*`. The tag value becomes the `PackageVersion`.
 
 **CI thresholds:** code coverage warning at 99%, failure below 52%; mutation score failure below 32%.
+
+**Known execution gaps:** parameters, aggregates outside the `groupBy` projection, computed `select` columns, and single-value `Arithmetic` are not yet implemented — see [`EXECUTION_GAPS.md`](EXECUTION_GAPS.md). These constructs raise `NotSupportedException` rather than silently producing wrong results.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,16 @@ public sealed record PureQLProjection : IStoredTableDataSet
 | `FROM` | Resolves `schema.table` path into a source `IStoredTableDataSet` |
 | `SELECT` | `ColumnsFromQuery` — derives column schema; `RowsFromDatasets` — projects row cells |
 | `JOIN` (INNER / LEFT / RIGHT / FULL) | `JoinApplicator` |
-| `WHERE` | `WhereExpressionBuilder` — compiles a `BooleanReturning` AST node into a `Func<IRow, bool>` |
-| `ORDER BY` | `OrderByApplicator` |
+| `WHERE` | `WhereExpressionBuilder` — compiles `BooleanReturning` and per-row `BooleanArrayReturning` (`each*`) AST nodes into a `Func<IRow, bool>` |
+| `ORDER BY` | `OrderByApplicator` — honours per-item `SortDirection` (`Asc` / `Desc`) |
 | `GROUP BY` / `HAVING` | `GroupByApplicator` |
 | `LIMIT` / `OFFSET` (`Pagination`) | `.Skip().Take()` |
+| `DISTINCT` | `DistinctApplicator` |
+| `each*` predicates / arithmetic | Per-row evaluation in `WhereExpressionBuilder` — supports `EachEquality`, `EachComparison`, `EachAnd`/`EachOr`/`EachNot`, `EachArithmetic`, `EachDateAddDays` / `EachDateDiffDays`, `EachTimeAddSeconds` / `EachTimeDiffSeconds`, `EachDateTimeAddSeconds` / `EachDateTimeDiffSeconds` inside filters and join conditions |
+
+Constructs the executor does not yet implement (parameters, aggregates
+outside `groupBy`, computed `select` columns, single-value `Arithmetic`)
+are documented in [`EXECUTION_GAPS.md`](EXECUTION_GAPS.md).
 
 ## Dependencies
 
@@ -49,7 +55,7 @@ public sealed record PureQLProjection : IStoredTableDataSet
 - [`Pure.RelationalSchema`](https://github.com/kudima03/Pure.RelationalSchema/tree/2.0.0) — relational schema abstractions (`ISchema`, `ITable`, `IColumn`, column type hierarchy)
 - [`Pure.RelationalSchema.HashCodes`](https://github.com/kudima03/Pure.RelationalSchema.HashCodes/tree/3.3.0) — structural hash codes for relational schema types
 - [`Pure.RelationalSchema.Storage`](https://github.com/kudima03/Pure.RelationalSchema.Storage/tree/0.1.0-preview.7.0.0) — in-memory relational data model (`IStoredSchemaDataSet`, `IStoredTableDataSet`, `IRow`, `ICell`)
-- [`PureQL.CSharp.Model`](https://github.com/kudima03/PureQL.CSharp.Model/tree/0.1.0-preview.10.0.0) — PureQL query AST (`Query`, `SelectExpression`, `BooleanReturning`, `Join`, `Pagination`, …)
+- [`PureQL.CSharp.Model`](https://github.com/kudima03/PureQL.CSharp.Model/tree/0.1.0-preview.11.0.0) — PureQL query AST (`Query`, `SelectExpression`, `BooleanReturning`, `BooleanArrayReturning`, `Join`, `OrderByItem`, `Pagination`, …) — tracks PureQL specification `0.1.0-preview.0.5.0`
 - [`Pure.Collections.Generic`](https://github.com/kudima03/Pure.Collections.Generic/tree/0.1.0-preview.3.0.0) — generic collection utilities used in row projection
 
 ## Target Frameworks

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/DistinctApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/DistinctApplicator.cs
@@ -1,0 +1,35 @@
+using Pure.RelationalSchema.Storage.Abstractions;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection;
+
+internal static class DistinctApplicator
+{
+    internal static IQueryable<IRow> Apply(IQueryable<IRow> source)
+    {
+        HashSet<string> seen = [];
+
+        List<IRow> result = [];
+
+        foreach (IRow row in source.AsEnumerable())
+        {
+            string key = BuildKey(row);
+
+            if (seen.Add(key))
+            {
+                result.Add(row);
+            }
+        }
+
+        return result.AsQueryable();
+    }
+
+    private static string BuildKey(IRow row)
+    {
+        return string.Join(
+            "\0",
+            row.Cells
+                .OrderBy(c => c.Key.Name.TextValue, StringComparer.Ordinal)
+                .Select(c => c.Key.Name.TextValue + "=" + (c.Value.Value.TextValue ?? ""))
+        );
+    }
+}

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/GroupByApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/GroupByApplicator.cs
@@ -42,6 +42,7 @@ internal static class GroupByApplicator
                     f =>
                         CellValueExtractor.GetDateTimeValue(row, f.Field)?.ToString()
                         ?? string.Empty,
+                    _ => string.Empty,
                     f =>
                         CellValueExtractor.GetDoubleValue(row, f.Field)?.ToString()
                         ?? string.Empty,

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/JoinApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/JoinApplicator.cs
@@ -26,7 +26,9 @@ internal static class JoinApplicator
             .First(x => x.Key.Name.TextValue == tableName)
             .Value;
 
-        Func<IRow, bool> onCondition = WhereExpressionBuilder.Build(join.On).Compile();
+        Func<IRow, bool> onCondition = WhereExpressionBuilder
+            .BuildPredicate(join.On)
+            .Compile();
 
         List<IRow> leftList = [.. left];
         List<IRow> rightList = [.. right];

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/OrderByApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/OrderByApplicator.cs
@@ -1,5 +1,5 @@
 using Pure.RelationalSchema.Storage.Abstractions;
-using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection;
 
@@ -7,16 +7,16 @@ internal static class OrderByApplicator
 {
     internal static IQueryable<IRow> Apply(
         IQueryable<IRow> source,
-        IEnumerable<Field> fields
+        IEnumerable<OrderByItem> items
     )
     {
         IOrderedQueryable<IRow>? ordered = null;
 
-        foreach (Field field in fields)
+        foreach (OrderByItem item in items)
         {
             ordered = ordered is null
-                ? ApplyFirstOrderBy(source, field)
-                : ApplyThenBy(ordered, field);
+                ? ApplyFirstOrderBy(source, item)
+                : ApplyThenBy(ordered, item);
         }
 
         return ordered ?? source;
@@ -24,33 +24,143 @@ internal static class OrderByApplicator
 
     private static IOrderedQueryable<IRow> ApplyFirstOrderBy(
         IQueryable<IRow> source,
-        Field field
+        OrderByItem item
     )
     {
-        return field.Match(
-            f => source.OrderBy(row => CellValueExtractor.GetBoolValue(row, f.Field)),
-            f => source.OrderBy(row => CellValueExtractor.GetDateOnlyValue(row, f.Field)),
-            f => source.OrderBy(row => CellValueExtractor.GetDateTimeValue(row, f.Field)),
-            f => source.OrderBy(row => CellValueExtractor.GetDoubleValue(row, f.Field)),
-            f => source.OrderBy(row => CellValueExtractor.GetTimeOnlyValue(row, f.Field)),
-            f => source.OrderBy(row => CellValueExtractor.GetGuidValue(row, f.Field)),
-            f => source.OrderBy(row => CellValueExtractor.GetTextValue(row, f.Field))
+        bool descending = item.Direction == SortDirection.Desc;
+
+        return item.Field.Match(
+            f =>
+                descending
+                    ? source.OrderByDescending(row =>
+                        CellValueExtractor.GetBoolValue(row, f.Field)
+                    )
+                    : source.OrderBy(row =>
+                        CellValueExtractor.GetBoolValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.OrderByDescending(row =>
+                        CellValueExtractor.GetDateOnlyValue(row, f.Field)
+                    )
+                    : source.OrderBy(row =>
+                        CellValueExtractor.GetDateOnlyValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.OrderByDescending(row =>
+                        CellValueExtractor.GetDateTimeValue(row, f.Field)
+                    )
+                    : source.OrderBy(row =>
+                        CellValueExtractor.GetDateTimeValue(row, f.Field)
+                    ),
+            _ =>
+                descending
+                    ? source.OrderByDescending(_ => (string?)null)
+                    : source.OrderBy(_ => (string?)null),
+            f =>
+                descending
+                    ? source.OrderByDescending(row =>
+                        CellValueExtractor.GetDoubleValue(row, f.Field)
+                    )
+                    : source.OrderBy(row =>
+                        CellValueExtractor.GetDoubleValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.OrderByDescending(row =>
+                        CellValueExtractor.GetTimeOnlyValue(row, f.Field)
+                    )
+                    : source.OrderBy(row =>
+                        CellValueExtractor.GetTimeOnlyValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.OrderByDescending(row =>
+                        CellValueExtractor.GetGuidValue(row, f.Field)
+                    )
+                    : source.OrderBy(row =>
+                        CellValueExtractor.GetGuidValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.OrderByDescending(row =>
+                        CellValueExtractor.GetTextValue(row, f.Field)
+                    )
+                    : source.OrderBy(row =>
+                        CellValueExtractor.GetTextValue(row, f.Field)
+                    )
         );
     }
 
     private static IOrderedQueryable<IRow> ApplyThenBy(
         IOrderedQueryable<IRow> source,
-        Field field
+        OrderByItem item
     )
     {
-        return field.Match(
-            f => source.ThenBy(row => CellValueExtractor.GetBoolValue(row, f.Field)),
-            f => source.ThenBy(row => CellValueExtractor.GetDateOnlyValue(row, f.Field)),
-            f => source.ThenBy(row => CellValueExtractor.GetDateTimeValue(row, f.Field)),
-            f => source.ThenBy(row => CellValueExtractor.GetDoubleValue(row, f.Field)),
-            f => source.ThenBy(row => CellValueExtractor.GetTimeOnlyValue(row, f.Field)),
-            f => source.ThenBy(row => CellValueExtractor.GetGuidValue(row, f.Field)),
-            f => source.ThenBy(row => CellValueExtractor.GetTextValue(row, f.Field))
+        bool descending = item.Direction == SortDirection.Desc;
+
+        return item.Field.Match(
+            f =>
+                descending
+                    ? source.ThenByDescending(row =>
+                        CellValueExtractor.GetBoolValue(row, f.Field)
+                    )
+                    : source.ThenBy(row =>
+                        CellValueExtractor.GetBoolValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.ThenByDescending(row =>
+                        CellValueExtractor.GetDateOnlyValue(row, f.Field)
+                    )
+                    : source.ThenBy(row =>
+                        CellValueExtractor.GetDateOnlyValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.ThenByDescending(row =>
+                        CellValueExtractor.GetDateTimeValue(row, f.Field)
+                    )
+                    : source.ThenBy(row =>
+                        CellValueExtractor.GetDateTimeValue(row, f.Field)
+                    ),
+            _ =>
+                descending
+                    ? source.ThenByDescending(_ => (string?)null)
+                    : source.ThenBy(_ => (string?)null),
+            f =>
+                descending
+                    ? source.ThenByDescending(row =>
+                        CellValueExtractor.GetDoubleValue(row, f.Field)
+                    )
+                    : source.ThenBy(row =>
+                        CellValueExtractor.GetDoubleValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.ThenByDescending(row =>
+                        CellValueExtractor.GetTimeOnlyValue(row, f.Field)
+                    )
+                    : source.ThenBy(row =>
+                        CellValueExtractor.GetTimeOnlyValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.ThenByDescending(row =>
+                        CellValueExtractor.GetGuidValue(row, f.Field)
+                    )
+                    : source.ThenBy(row =>
+                        CellValueExtractor.GetGuidValue(row, f.Field)
+                    ),
+            f =>
+                descending
+                    ? source.ThenByDescending(row =>
+                        CellValueExtractor.GetTextValue(row, f.Field)
+                    )
+                    : source.ThenBy(row =>
+                        CellValueExtractor.GetTextValue(row, f.Field)
+                    )
         );
     }
 }

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/Pure.RelationalSchema.Storage.PureQL.Projection.csproj
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/Pure.RelationalSchema.Storage.PureQL.Projection.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Pure.RelationalSchema" Version="2.0.2" />
     <PackageReference Include="Pure.RelationalSchema.HashCodes" Version="3.3.0" />
     <PackageReference Include="Pure.RelationalSchema.Storage" Version="0.1.0-preview.8.0.0" />
-    <PackageReference Include="PureQL.CSharp.Model" Version="0.1.0-preview.10.0.0" />
+    <PackageReference Include="PureQL.CSharp.Model" Version="0.1.0-preview.11.0.0" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
     <PackageReference Include="Pure.Collections.Generic" Version="0.1.0-preview.3.0.0" />
   </ItemGroup>

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
@@ -68,7 +68,9 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
 
         if (query.Where is not null)
         {
-            queryable = queryable.Where(WhereExpressionBuilder.Build(query.Where));
+            queryable = queryable.Where(
+                WhereExpressionBuilder.BuildPredicate(query.Where.Value)
+            );
         }
 
         if (query.OrderBy is not null)
@@ -79,6 +81,11 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
         if (query.GroupBy is not null)
         {
             queryable = GroupByApplicator.Apply(queryable, query.GroupBy, query.Having);
+        }
+
+        if (query.Distinct)
+        {
+            queryable = DistinctApplicator.Apply(queryable);
         }
 
         if (query.Pagination is not null)

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/WhereExpressionBuilder.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/WhereExpressionBuilder.cs
@@ -1,24 +1,29 @@
 using System.Linq.Expressions;
 using System.Reflection;
+using OneOf;
 using Pure.RelationalSchema.Storage.Abstractions;
 using PureQL.CSharp.Model.ArrayEqualities;
 using PureQL.CSharp.Model.ArrayReturnings;
 using PureQL.CSharp.Model.BooleanOperations;
 using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.EachArithmetics;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachDateArithmetics;
+using PureQL.CSharp.Model.EachDateTimeArithmetics;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.EachTimeArithmetics;
 using PureQL.CSharp.Model.Equalities;
 using PureQL.CSharp.Model.Returnings;
 using ModelEquality = PureQL.CSharp.Model.Equality;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection;
 
-/// <summary>
-/// Translates a PureQL <see cref="BooleanReturning"/> AST node into a LINQ expression tree
-/// suitable for use with <see cref="IQueryable{T}.Where"/>.
-/// </summary>
 internal static class WhereExpressionBuilder
 {
-    // *ArrayReturning field position is T1 for all types.
-    // Scalar position differs: T0 for BooleanArrayReturning, T2 for all others.
+    private const string ParameterNotSupported =
+        "Parameter binding is not supported in expression tree translation.";
+    private const string AggregateNotSupported =
+        "Aggregate expressions are not supported outside groupBy projection.";
 
     private static readonly MethodInfo GetTextValueMethod =
         typeof(CellValueExtractor).GetMethod(
@@ -69,16 +74,25 @@ internal static class WhereExpressionBuilder
         return Expression.Lambda<Func<IRow, bool>>(body, rowParam);
     }
 
+    internal static Expression<Func<IRow, bool>> BuildPredicate(
+        OneOf<BooleanReturning, BooleanArrayReturning> condition
+    )
+    {
+        ParameterExpression rowParam = Expression.Parameter(typeof(IRow), "row");
+        Expression body = condition.Match(
+            single => BuildBoolean(single, rowParam),
+            each => BuildBoolArrayPerRow(each, rowParam)
+        );
+        return Expression.Lambda<Func<IRow, bool>>(body, rowParam);
+    }
+
     private static Expression BuildBoolean(
         BooleanReturning returning,
         ParameterExpression row
     )
     {
         return returning.Match(
-            _ =>
-                throw new NotSupportedException(
-                    "Parameter binding is not supported in expression tree translation."
-                ),
+            _ => throw new NotSupportedException(ParameterNotSupported),
             scalar => Expression.Constant(scalar.Value),
             equality => BuildEquality(equality, row),
             op => BuildBooleanOperator(op, row),
@@ -146,9 +160,7 @@ internal static class WhereExpressionBuilder
     )
     {
         return equality.Match(
-            // BooleanArrayReturning: T0=BooleanArrayScalar, T1=BooleanField, T2=BooleanArrayParameter
             eq => BuildBoolArrayEquality(eq, row),
-            // All others: T0=*ArrayParameter, T1=*Field, T2=*ArrayScalar
             eq =>
                 BuildContainmentEquality(
                     left: eq.Left.IsT1,
@@ -228,7 +240,6 @@ internal static class WhereExpressionBuilder
         );
     }
 
-    // BooleanArrayReturning has T0=Scalar, T1=Field, T2=Parameter (reversed from other types)
     private static Expression BuildBoolArrayEquality(
         BooleanArrayEquality eq,
         ParameterExpression row
@@ -281,7 +292,6 @@ internal static class WhereExpressionBuilder
             )
             .MakeGenericMethod(typeof(T));
 
-        // field vs scalar  →  scalar.Contains(cellValue)
         if (left && rightScalar is not null)
         {
             Expression fieldExpr = Expression.Call(
@@ -296,7 +306,6 @@ internal static class WhereExpressionBuilder
             return Expression.Call(containsMethod, scalarExpr, fieldExpr);
         }
 
-        // scalar vs field  →  scalar.Contains(cellValue)
         if (right && leftScalar is not null)
         {
             Expression fieldExpr = Expression.Call(
@@ -311,7 +320,6 @@ internal static class WhereExpressionBuilder
             return Expression.Call(containsMethod, scalarExpr, fieldExpr);
         }
 
-        // field vs field  →  cellValue1 == cellValue2
         if (left && right)
         {
             Expression left1 = Expression.Call(
@@ -327,7 +335,6 @@ internal static class WhereExpressionBuilder
             return Expression.Equal(left1, right1);
         }
 
-        // scalar vs scalar  →  constant SequenceEqual
         if (leftScalar is not null && rightScalar is not null)
         {
             MethodInfo sequenceEqual = typeof(Enumerable)
@@ -345,9 +352,7 @@ internal static class WhereExpressionBuilder
             return Expression.Call(sequenceEqual, leftConst, rightConst);
         }
 
-        throw new NotSupportedException(
-            "Parameter binding is not supported in expression tree translation."
-        );
+        throw new NotSupportedException(ParameterNotSupported);
     }
 
     private static Expression BuildBooleanOperator(
@@ -363,7 +368,7 @@ internal static class WhereExpressionBuilder
                             .Select(c => BuildBoolean(c, row))
                             .Aggregate(Expression.AndAlso),
                     arrayReturning =>
-                        BuildBoolArrayReturningAsSingleBool(arrayReturning, row)
+                        BuildBoolArrayPerRow(arrayReturning, row)
                 ),
             or =>
                 or.Conditions.Match(
@@ -372,19 +377,20 @@ internal static class WhereExpressionBuilder
                             .Select(c => BuildBoolean(c, row))
                             .Aggregate(Expression.OrElse),
                     arrayReturning =>
-                        BuildBoolArrayReturningAsSingleBool(arrayReturning, row)
+                        BuildBoolArrayPerRow(arrayReturning, row)
                 ),
             not => Expression.Not(BuildBoolean(not.Condition, row))
         );
     }
 
-    // BooleanArrayReturning: T0=BooleanArrayScalar, T1=BooleanField, T2=BooleanArrayParameter
-    private static Expression BuildBoolArrayReturningAsSingleBool(
+    // ===== Per-row evaluation of BooleanArrayReturning =====
+
+    private static Expression BuildBoolArrayPerRow(
         BooleanArrayReturning returning,
         ParameterExpression row
     )
     {
-        return returning.Match<Expression>(
+        return returning.Match(
             scalar => Expression.Constant(scalar.Value.All(v => v)),
             field =>
                 Expression.Equal(
@@ -395,12 +401,597 @@ internal static class WhereExpressionBuilder
                     ),
                     Expression.Constant((bool?)true, typeof(bool?))
                 ),
-            _ =>
-                throw new NotSupportedException(
-                    "Parameter binding is not supported in expression tree translation."
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            comparison => BuildEachComparisonPerRow(comparison, row),
+            equality => BuildEachEqualityPerRow(equality, row),
+            and =>
+                and.Conditions
+                    .Select(c => BuildBoolArrayPerRow(c, row))
+                    .Aggregate(Expression.AndAlso),
+            or =>
+                or.Conditions
+                    .Select(c => BuildBoolArrayPerRow(c, row))
+                    .Aggregate(Expression.OrElse),
+            not => Expression.Not(BuildBoolArrayPerRow(not.Condition, row))
+        );
+    }
+
+    private static Expression BuildEachEqualityPerRow(
+        EachEquality equality,
+        ParameterExpression row
+    )
+    {
+        return equality.Match(
+            eq =>
+                Expression.Equal(
+                    BuildBoolArrayValuePerRow(eq.Left, row),
+                    BuildBoolPerRow(eq.Right, row)
+                ),
+            eq =>
+                Expression.Equal(
+                    BuildNumberArrayValuePerRow(eq.Left, row),
+                    BuildNumberPerRow(eq.Right, row)
+                ),
+            eq =>
+                Expression.Equal(
+                    BuildStringArrayValuePerRow(eq.Left, row),
+                    BuildStringPerRow(eq.Right, row)
+                ),
+            eq =>
+                Expression.Equal(
+                    BuildDateArrayValuePerRow(eq.Left, row),
+                    BuildDatePerRow(eq.Right, row)
+                ),
+            eq =>
+                Expression.Equal(
+                    BuildTimeArrayValuePerRow(eq.Left, row),
+                    BuildTimePerRow(eq.Right, row)
+                ),
+            eq =>
+                Expression.Equal(
+                    BuildDateTimeArrayValuePerRow(eq.Left, row),
+                    BuildDateTimePerRow(eq.Right, row)
+                ),
+            eq =>
+                Expression.Equal(
+                    BuildUuidArrayValuePerRow(eq.Left, row),
+                    BuildUuidPerRow(eq.Right, row)
                 )
         );
     }
+
+    private static Expression BuildEachComparisonPerRow(
+        EachComparison comparison,
+        ParameterExpression row
+    )
+    {
+        return comparison.Match(
+            c =>
+                BuildTypedComparison(
+                    BuildNumberArrayValuePerRow(c.Left, row),
+                    BuildNumberPerRow(c.Right, row),
+                    ToComparisonOperator(c.Operator)
+                ),
+            c =>
+                BuildTypedComparison(
+                    BuildStringArrayValuePerRow(c.Left, row),
+                    BuildStringPerRow(c.Right, row),
+                    ToComparisonOperator(c.Operator)
+                ),
+            c =>
+                BuildTypedComparison(
+                    BuildDateArrayValuePerRow(c.Left, row),
+                    BuildDatePerRow(c.Right, row),
+                    ToComparisonOperator(c.Operator)
+                ),
+            c =>
+                BuildTypedComparison(
+                    BuildDateTimeArrayValuePerRow(c.Left, row),
+                    BuildDateTimePerRow(c.Right, row),
+                    ToComparisonOperator(c.Operator)
+                ),
+            c =>
+                BuildTypedComparison(
+                    BuildTimeArrayValuePerRow(c.Left, row),
+                    BuildTimePerRow(c.Right, row),
+                    ToComparisonOperator(c.Operator)
+                )
+        );
+    }
+
+    private static ComparisonOperator ToComparisonOperator(EachComparisonOperator op)
+    {
+        return op switch
+        {
+            EachComparisonOperator.EachGreaterThan => ComparisonOperator.GreaterThan,
+            EachComparisonOperator.EachGreaterThanOrEqual =>
+                ComparisonOperator.GreaterThanOrEqual,
+            EachComparisonOperator.EachLessThan => ComparisonOperator.LessThan,
+            EachComparisonOperator.EachLessThanOrEqual =>
+                ComparisonOperator.LessThanOrEqual,
+            _ => throw new NotSupportedException($"Unknown each operator: {op}"),
+        };
+    }
+
+    private static Expression BuildBoolPerRow(
+        OneOf<BooleanReturning, BooleanArrayReturning> value,
+        ParameterExpression row
+    )
+    {
+        return value.Match(
+            BuildBoolReturningAsExpr,
+            each => BuildBoolArrayValuePerRow(each, row)
+        );
+    }
+
+    private static Expression BuildNumberPerRow(
+        OneOf<NumberReturning, NumberArrayReturning> value,
+        ParameterExpression row
+    )
+    {
+        return value.Match(
+            BuildNumberReturningAsExpr,
+            each => BuildNumberArrayValuePerRow(each, row)
+        );
+    }
+
+    private static Expression BuildStringPerRow(
+        OneOf<StringReturning, StringArrayReturning> value,
+        ParameterExpression row
+    )
+    {
+        return value.Match(
+            BuildStringReturningAsExpr,
+            each => BuildStringArrayValuePerRow(each, row)
+        );
+    }
+
+    private static Expression BuildDatePerRow(
+        OneOf<DateReturning, DateArrayReturning> value,
+        ParameterExpression row
+    )
+    {
+        return value.Match(
+            BuildDateReturningAsExpr,
+            each => BuildDateArrayValuePerRow(each, row)
+        );
+    }
+
+    private static Expression BuildTimePerRow(
+        OneOf<TimeReturning, TimeArrayReturning> value,
+        ParameterExpression row
+    )
+    {
+        return value.Match(
+            BuildTimeReturningAsExpr,
+            each => BuildTimeArrayValuePerRow(each, row)
+        );
+    }
+
+    private static Expression BuildDateTimePerRow(
+        OneOf<DateTimeReturning, DateTimeArrayReturning> value,
+        ParameterExpression row
+    )
+    {
+        return value.Match(
+            BuildDateTimeReturningAsExpr,
+            each => BuildDateTimeArrayValuePerRow(each, row)
+        );
+    }
+
+    private static Expression BuildUuidPerRow(
+        OneOf<UuidReturning, UuidArrayReturning> value,
+        ParameterExpression row
+    )
+    {
+        return value.Match(
+            BuildUuidReturningAsExpr,
+            each => BuildUuidArrayValuePerRow(each, row)
+        );
+    }
+
+    private static Expression BuildBoolArrayValuePerRow(
+        BooleanArrayReturning returning,
+        ParameterExpression row
+    )
+    {
+        return returning.Match<Expression>(
+            scalar => Expression.Constant(
+                (bool?)scalar.Value.FirstOrDefault(),
+                typeof(bool?)
+            ),
+            field =>
+                Expression.Call(
+                    GetBoolValueMethod,
+                    row,
+                    Expression.Constant(field.Field)
+                ),
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            _ => throw new NotSupportedException(
+                "Nested each-comparison as a boolean value is not supported."
+            ),
+            _ => throw new NotSupportedException(
+                "Nested each-equality as a boolean value is not supported."
+            ),
+            _ => throw new NotSupportedException(
+                "Nested each-and as a boolean value is not supported."
+            ),
+            _ => throw new NotSupportedException(
+                "Nested each-or as a boolean value is not supported."
+            ),
+            _ => throw new NotSupportedException(
+                "Nested each-not as a boolean value is not supported."
+            )
+        );
+    }
+
+    private static Expression BuildNumberArrayValuePerRow(
+        NumberArrayReturning returning,
+        ParameterExpression row
+    )
+    {
+        return returning.Match(
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            field =>
+                Expression.Call(
+                    GetDoubleValueMethod,
+                    row,
+                    Expression.Constant(field.Field)
+                ),
+            scalar => Expression.Constant(
+                (double?)scalar.Value.FirstOrDefault(),
+                typeof(double?)
+            ),
+            arithmetic => BuildEachArithmeticPerRow(arithmetic, row),
+            diff => BuildEachDateDiffDaysPerRow(diff, row),
+            diff => BuildEachDateTimeDiffSecondsPerRow(diff, row),
+            diff => BuildEachTimeDiffSecondsPerRow(diff, row)
+        );
+    }
+
+    private static Expression BuildStringArrayValuePerRow(
+        StringArrayReturning returning,
+        ParameterExpression row
+    )
+    {
+        return returning.Match<Expression>(
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            field =>
+                Expression.Call(
+                    GetTextValueMethod,
+                    row,
+                    Expression.Constant(field.Field)
+                ),
+            scalar => Expression.Constant(
+                scalar.Value.FirstOrDefault(),
+                typeof(string)
+            )
+        );
+    }
+
+    private static Expression BuildDateArrayValuePerRow(
+        DateArrayReturning returning,
+        ParameterExpression row
+    )
+    {
+        return returning.Match(
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            field =>
+                Expression.Call(
+                    GetDateOnlyValueMethod,
+                    row,
+                    Expression.Constant(field.Field)
+                ),
+            scalar => Expression.Constant(
+                (DateOnly?)scalar.Value.FirstOrDefault(),
+                typeof(DateOnly?)
+            ),
+            addDays => BuildEachDateAddDaysPerRow(addDays, row)
+        );
+    }
+
+    private static Expression BuildTimeArrayValuePerRow(
+        TimeArrayReturning returning,
+        ParameterExpression row
+    )
+    {
+        return returning.Match(
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            field =>
+                Expression.Call(
+                    GetTimeOnlyValueMethod,
+                    row,
+                    Expression.Constant(field.Field)
+                ),
+            scalar => Expression.Constant(
+                (TimeOnly?)scalar.Value.FirstOrDefault(),
+                typeof(TimeOnly?)
+            ),
+            addSeconds => BuildEachTimeAddSecondsPerRow(addSeconds, row)
+        );
+    }
+
+    private static Expression BuildDateTimeArrayValuePerRow(
+        DateTimeArrayReturning returning,
+        ParameterExpression row
+    )
+    {
+        return returning.Match(
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            field =>
+                Expression.Call(
+                    GetDateTimeValueMethod,
+                    row,
+                    Expression.Constant(field.Field)
+                ),
+            scalar => Expression.Constant(
+                (DateTime?)scalar.Value.FirstOrDefault(),
+                typeof(DateTime?)
+            ),
+            addSeconds => BuildEachDateTimeAddSecondsPerRow(addSeconds, row)
+        );
+    }
+
+    private static Expression BuildUuidArrayValuePerRow(
+        UuidArrayReturning returning,
+        ParameterExpression row
+    )
+    {
+        return returning.Match<Expression>(
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            field =>
+                Expression.Call(
+                    GetGuidValueMethod,
+                    row,
+                    Expression.Constant(field.Field)
+                ),
+            scalar => Expression.Constant(
+                (Guid?)scalar.Value.FirstOrDefault(),
+                typeof(Guid?)
+            )
+        );
+    }
+
+    // ===== EachArithmetic per row =====
+
+    private static Expression BuildEachArithmeticPerRow(
+        EachArithmetic arithmetic,
+        ParameterExpression row
+    )
+    {
+        return arithmetic.Match(
+            add =>
+                add.Values
+                    .Select(v => BuildNumberPerRow(v, row))
+                    .Aggregate(NullableDoubleAdd),
+            sub =>
+                sub.Values
+                    .Select(v => BuildNumberPerRow(v, row))
+                    .Aggregate(NullableDoubleSubtract),
+            mul =>
+                mul.Values
+                    .Select(v => BuildNumberPerRow(v, row))
+                    .Aggregate(NullableDoubleMultiply),
+            div =>
+                div.Values
+                    .Select(v => BuildNumberPerRow(v, row))
+                    .Aggregate(NullableDoubleDivide)
+        );
+    }
+
+    private static readonly MethodInfo AddNullableDoubleMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(AddDoubles),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    private static readonly MethodInfo SubtractNullableDoubleMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(SubtractDoubles),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    private static readonly MethodInfo MultiplyNullableDoubleMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(MultiplyDoubles),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    private static readonly MethodInfo DivideNullableDoubleMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(DivideDoubles),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    internal static double? AddDoubles(double? a, double? b)
+    {
+        return a.HasValue && b.HasValue ? a.Value + b.Value : null;
+    }
+
+    internal static double? SubtractDoubles(double? a, double? b)
+    {
+        return a.HasValue && b.HasValue ? a.Value - b.Value : null;
+    }
+
+    internal static double? MultiplyDoubles(double? a, double? b)
+    {
+        return a.HasValue && b.HasValue ? a.Value * b.Value : null;
+    }
+
+    internal static double? DivideDoubles(double? a, double? b)
+    {
+        return a.HasValue && b.HasValue && b.Value != 0 ? a.Value / b.Value : null;
+    }
+
+    private static Expression NullableDoubleAdd(Expression a, Expression b)
+    {
+        return Expression.Call(AddNullableDoubleMethod, a, b);
+    }
+
+    private static Expression NullableDoubleSubtract(Expression a, Expression b)
+    {
+        return Expression.Call(SubtractNullableDoubleMethod, a, b);
+    }
+
+    private static Expression NullableDoubleMultiply(Expression a, Expression b)
+    {
+        return Expression.Call(MultiplyNullableDoubleMethod, a, b);
+    }
+
+    private static Expression NullableDoubleDivide(Expression a, Expression b)
+    {
+        return Expression.Call(DivideNullableDoubleMethod, a, b);
+    }
+
+    // ===== Date/Time/DateTime per-row arithmetic =====
+
+    private static readonly MethodInfo AddDaysMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(AddDays),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    private static readonly MethodInfo DiffDaysMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(DiffDays),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    private static readonly MethodInfo AddSecondsToTimeMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(AddSecondsToTime),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    private static readonly MethodInfo DiffSecondsTimeMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(DiffSecondsTime),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    private static readonly MethodInfo AddSecondsToDateTimeMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(AddSecondsToDateTime),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    private static readonly MethodInfo DiffSecondsDateTimeMethod =
+        typeof(WhereExpressionBuilder).GetMethod(
+            nameof(DiffSecondsDateTime),
+            BindingFlags.NonPublic | BindingFlags.Static
+        )!;
+
+    internal static DateOnly? AddDays(DateOnly? d, double? n)
+    {
+        return d.HasValue && n.HasValue ? d.Value.AddDays((int)n.Value) : null;
+    }
+
+    internal static double? DiffDays(DateOnly? l, DateOnly? r)
+    {
+        return l.HasValue && r.HasValue
+            ? (l.Value.DayNumber - r.Value.DayNumber)
+            : null;
+    }
+
+    internal static TimeOnly? AddSecondsToTime(TimeOnly? t, double? n)
+    {
+        return t.HasValue && n.HasValue
+            ? t.Value.Add(TimeSpan.FromSeconds(n.Value))
+            : null;
+    }
+
+    internal static double? DiffSecondsTime(TimeOnly? l, TimeOnly? r)
+    {
+        return l.HasValue && r.HasValue
+            ? (l.Value - r.Value).TotalSeconds
+            : null;
+    }
+
+    internal static DateTime? AddSecondsToDateTime(DateTime? d, double? n)
+    {
+        return d.HasValue && n.HasValue
+            ? d.Value.AddSeconds(n.Value)
+            : null;
+    }
+
+    internal static double? DiffSecondsDateTime(DateTime? l, DateTime? r)
+    {
+        return l.HasValue && r.HasValue ? (l.Value - r.Value).TotalSeconds : null;
+    }
+
+    private static Expression BuildEachDateAddDaysPerRow(
+        EachDateAddDays op,
+        ParameterExpression row
+    )
+    {
+        return Expression.Call(
+            AddDaysMethod,
+            BuildDatePerRow(op.Left, row),
+            BuildNumberPerRow(op.Right, row)
+        );
+    }
+
+    private static Expression BuildEachDateDiffDaysPerRow(
+        EachDateDiffDays op,
+        ParameterExpression row
+    )
+    {
+        return Expression.Call(
+            DiffDaysMethod,
+            BuildDatePerRow(op.Left, row),
+            BuildDatePerRow(op.Right, row)
+        );
+    }
+
+    private static Expression BuildEachTimeAddSecondsPerRow(
+        EachTimeAddSeconds op,
+        ParameterExpression row
+    )
+    {
+        return Expression.Call(
+            AddSecondsToTimeMethod,
+            BuildTimePerRow(op.Left, row),
+            BuildNumberPerRow(op.Right, row)
+        );
+    }
+
+    private static Expression BuildEachTimeDiffSecondsPerRow(
+        EachTimeDiffSeconds op,
+        ParameterExpression row
+    )
+    {
+        return Expression.Call(
+            DiffSecondsTimeMethod,
+            BuildTimePerRow(op.Left, row),
+            BuildTimePerRow(op.Right, row)
+        );
+    }
+
+    private static Expression BuildEachDateTimeAddSecondsPerRow(
+        EachDateTimeAddSeconds op,
+        ParameterExpression row
+    )
+    {
+        return Expression.Call(
+            AddSecondsToDateTimeMethod,
+            BuildDateTimePerRow(op.Left, row),
+            BuildNumberPerRow(op.Right, row)
+        );
+    }
+
+    private static Expression BuildEachDateTimeDiffSecondsPerRow(
+        EachDateTimeDiffSeconds op,
+        ParameterExpression row
+    )
+    {
+        return Expression.Call(
+            DiffSecondsDateTimeMethod,
+            BuildDateTimePerRow(op.Left, row),
+            BuildDateTimePerRow(op.Right, row)
+        );
+    }
+
+    // ===== Comparison handling =====
 
     private static Expression BuildComparison(
         Comparison comparison
@@ -452,7 +1043,7 @@ internal static class WhereExpressionBuilder
         ComparisonOperator op
     )
     {
-        if (left.Type == typeof(string))
+        if (left.Type == typeof(string) || right.Type == typeof(string))
         {
             Expression compareExpr = Expression.Call(
                 StringCompareOrdinalMethod,
@@ -494,73 +1085,79 @@ internal static class WhereExpressionBuilder
         };
     }
 
-    // Scalar-only returnings (no field access, row-independent expressions)
+    // ===== Scalar-only returnings =====
 
     private static Expression BuildBoolReturningAsExpr(BooleanReturning returning)
     {
         return returning.Match(
-            _ => throw new NotSupportedException("Parameter binding is not supported."),
-            scalar => Expression.Constant(scalar.Value, typeof(bool)),
-            _ =>
-                throw new NotSupportedException(
-                    "Nested equality in scalar boolean context is not supported."
-                ),
-            _ =>
-                throw new NotSupportedException(
-                    "Nested boolean operator in scalar boolean context is not supported."
-                ),
-            _ =>
-                throw new NotSupportedException(
-                    "Nested comparison in scalar boolean context is not supported."
-                )
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            scalar => Expression.Constant((bool?)scalar.Value, typeof(bool?)),
+            _ => throw new NotSupportedException(
+                "Nested equality in scalar boolean context is not supported."
+            ),
+            _ => throw new NotSupportedException(
+                "Nested boolean operator in scalar boolean context is not supported."
+            ),
+            _ => throw new NotSupportedException(
+                "Nested comparison in scalar boolean context is not supported."
+            )
         );
     }
 
     private static Expression BuildNumberReturningAsExpr(NumberReturning returning)
     {
         return returning.Match(
-            _ => throw new NotSupportedException("Parameter binding is not supported."),
-            scalar => Expression.Constant(scalar.Value, typeof(double))
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            scalar => Expression.Constant((double?)scalar.Value, typeof(double?)),
+            _ => throw new NotSupportedException(
+                "Single-value Arithmetic outside per-row context is not supported."
+            ),
+            _ => throw new NotSupportedException(AggregateNotSupported),
+            _ => throw new NotSupportedException(AggregateNotSupported)
         );
     }
 
     private static Expression BuildStringReturningAsExpr(StringReturning returning)
     {
         return returning.Match(
-            _ => throw new NotSupportedException("Parameter binding is not supported."),
-            scalar => Expression.Constant(scalar.Value, typeof(string))
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            scalar => Expression.Constant(scalar.Value, typeof(string)),
+            _ => throw new NotSupportedException(AggregateNotSupported)
         );
     }
 
     private static Expression BuildDateReturningAsExpr(DateReturning returning)
     {
         return returning.Match(
-            _ => throw new NotSupportedException("Parameter binding is not supported."),
-            scalar => Expression.Constant(scalar.Value, typeof(DateOnly))
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            scalar => Expression.Constant((DateOnly?)scalar.Value, typeof(DateOnly?)),
+            _ => throw new NotSupportedException(AggregateNotSupported)
         );
     }
 
     private static Expression BuildDateTimeReturningAsExpr(DateTimeReturning returning)
     {
         return returning.Match(
-            _ => throw new NotSupportedException("Parameter binding is not supported."),
-            scalar => Expression.Constant(scalar.Value, typeof(DateTime))
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            scalar => Expression.Constant((DateTime?)scalar.Value, typeof(DateTime?)),
+            _ => throw new NotSupportedException(AggregateNotSupported)
         );
     }
 
     private static Expression BuildTimeReturningAsExpr(TimeReturning returning)
     {
         return returning.Match(
-            _ => throw new NotSupportedException("Parameter binding is not supported."),
-            scalar => Expression.Constant(scalar.Value, typeof(TimeOnly))
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            scalar => Expression.Constant((TimeOnly?)scalar.Value, typeof(TimeOnly?)),
+            _ => throw new NotSupportedException(AggregateNotSupported)
         );
     }
 
     private static Expression BuildUuidReturningAsExpr(UuidReturning returning)
     {
         return returning.Match(
-            _ => throw new NotSupportedException("Parameter binding is not supported."),
-            scalar => Expression.Constant(scalar.Value, typeof(Guid))
+            _ => throw new NotSupportedException(ParameterNotSupported),
+            scalar => Expression.Constant((Guid?)scalar.Value, typeof(Guid?))
         );
     }
 }

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/CellValueExtractorTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/CellValueExtractorTests.cs
@@ -1,0 +1,161 @@
+using System.Reflection;
+using Pure.RelationalSchema.Abstractions.Column;
+using Pure.RelationalSchema.ColumnType;
+using Pure.RelationalSchema.HashCodes;
+using Pure.RelationalSchema.Storage.Abstractions;
+using String = Pure.Primitives.String.String;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests;
+
+public sealed record CellValueExtractorTests
+{
+    private static readonly Type ExtractorType = typeof(PureQLProjection)
+        .Assembly.GetType(
+            "Pure.RelationalSchema.Storage.PureQL.Projection.CellValueExtractor"
+        )!;
+
+    private static T? Invoke<T>(string name, IRow row, string fieldName)
+    {
+        MethodInfo m = ExtractorType.GetMethod(
+            name,
+            BindingFlags.Static | BindingFlags.NonPublic
+        )!;
+        return (T?)m.Invoke(null, [row, fieldName]);
+    }
+
+    private static IRow OneCellRow(string columnName, string cellValue)
+    {
+        IColumn column = new Column.Column(new String(columnName), new StringColumnType());
+        return new Row(
+            new Collections.Generic.Dictionary<IColumn, IColumn, ICell>(
+                [column],
+                c => c,
+                _ => new Cell(new String(cellValue)),
+                c => new ColumnHash(c)
+            )
+        );
+    }
+
+    [Fact]
+    public void GetTextValueReturnsCellTextWhenFieldExists()
+    {
+        IRow row = OneCellRow("name", "hello");
+        Assert.Equal("hello", Invoke<string>("GetTextValue", row, "name"));
+    }
+
+    [Fact]
+    public void GetTextValueReturnsNullWhenFieldDoesNotExist()
+    {
+        IRow row = OneCellRow("name", "hello");
+        Assert.Null(Invoke<string>("GetTextValue", row, "missing"));
+    }
+
+    [Fact]
+    public void GetDoubleValueParsesValidNumber()
+    {
+        IRow row = OneCellRow("n", "3.14");
+        Assert.Equal(3.14, Invoke<double?>("GetDoubleValue", row, "n"));
+    }
+
+    [Fact]
+    public void GetDoubleValueReturnsNullForNonNumeric()
+    {
+        IRow row = OneCellRow("n", "abc");
+        Assert.Null(Invoke<double?>("GetDoubleValue", row, "n"));
+    }
+
+    [Fact]
+    public void GetDoubleValueReturnsNullForMissingField()
+    {
+        IRow row = OneCellRow("n", "3.14");
+        Assert.Null(Invoke<double?>("GetDoubleValue", row, "missing"));
+    }
+
+    [Fact]
+    public void GetBoolValueParsesTrueAndFalse()
+    {
+        Assert.True(Invoke<bool?>("GetBoolValue", OneCellRow("b", "true"), "b"));
+        Assert.False(Invoke<bool?>("GetBoolValue", OneCellRow("b", "false"), "b"));
+    }
+
+    [Fact]
+    public void GetBoolValueReturnsNullForBadInput()
+    {
+        Assert.Null(Invoke<bool?>("GetBoolValue", OneCellRow("b", "yes"), "b"));
+    }
+
+    [Fact]
+    public void GetDateOnlyValueParsesIsoDate()
+    {
+        IRow row = OneCellRow("d", "2026-05-28");
+        Assert.Equal(
+            new DateOnly(2026, 5, 28),
+            Invoke<DateOnly?>("GetDateOnlyValue", row, "d")
+        );
+    }
+
+    [Fact]
+    public void GetDateOnlyValueReturnsNullForInvalid()
+    {
+        Assert.Null(Invoke<DateOnly?>(
+            "GetDateOnlyValue",
+            OneCellRow("d", "not-a-date"),
+            "d"
+        ));
+    }
+
+    [Fact]
+    public void GetDateTimeValueParsesIsoDateTime()
+    {
+        IRow row = OneCellRow("dt", "2026-05-28T12:34:56");
+        Assert.Equal(
+            new DateTime(2026, 5, 28, 12, 34, 56),
+            Invoke<DateTime?>("GetDateTimeValue", row, "dt")
+        );
+    }
+
+    [Fact]
+    public void GetDateTimeValueReturnsNullForInvalid()
+    {
+        Assert.Null(Invoke<DateTime?>(
+            "GetDateTimeValue",
+            OneCellRow("dt", "junk"),
+            "dt"
+        ));
+    }
+
+    [Fact]
+    public void GetTimeOnlyValueParsesIsoTime()
+    {
+        Assert.Equal(
+            new TimeOnly(13, 45, 0),
+            Invoke<TimeOnly?>("GetTimeOnlyValue", OneCellRow("t", "13:45"), "t")
+        );
+    }
+
+    [Fact]
+    public void GetTimeOnlyValueReturnsNullForInvalid()
+    {
+        Assert.Null(
+            Invoke<TimeOnly?>("GetTimeOnlyValue", OneCellRow("t", "??"), "t")
+        );
+    }
+
+    [Fact]
+    public void GetGuidValueParsesValidGuid()
+    {
+        Guid g = Guid.NewGuid();
+        Assert.Equal(
+            g,
+            Invoke<Guid?>("GetGuidValue", OneCellRow("u", g.ToString()), "u")
+        );
+    }
+
+    [Fact]
+    public void GetGuidValueReturnsNullForInvalid()
+    {
+        Assert.Null(
+            Invoke<Guid?>("GetGuidValue", OneCellRow("u", "not-a-guid"), "u")
+        );
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Helpers/QueryHelpers.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Helpers/QueryHelpers.cs
@@ -1,0 +1,91 @@
+using OneOf;
+using Pure.RelationalSchema.Abstractions.Column;
+using Pure.RelationalSchema.Abstractions.Schema;
+using Pure.RelationalSchema.Abstractions.Table;
+using Pure.RelationalSchema.Storage.Abstractions;
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Fakes;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Helpers;
+
+internal sealed record TestEnvironment(
+    ISchema Schema,
+    IStoredSchemaDataSet Dataset,
+    ITable Table,
+    IColumn First,
+    IColumn Second,
+    string SchemaName,
+    string TableName,
+    string Entity
+);
+
+internal static class QueryHelpers
+{
+    internal static TestEnvironment NewEnv()
+    {
+        ISchema schema = new FakeSchema();
+        IStoredSchemaDataSet dataset = new FakeStoredSchemaDataset(schema);
+        ITable table = schema.Tables.First();
+        IColumn first = table.Columns.First();
+        IColumn second = table.Columns.Skip(1).First();
+        string schemaName = schema.Name.TextValue;
+        string tableName = table.Name.TextValue;
+        return new TestEnvironment(
+            schema,
+            dataset,
+            table,
+            first,
+            second,
+            schemaName,
+            tableName,
+            $"{schemaName}.{tableName}"
+        );
+    }
+
+    internal static SelectExpression SelectStringField(
+        string entity,
+        string fieldName
+    )
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new StringArrayReturning(new StringField(entity, fieldName))
+            )
+        );
+    }
+
+    internal static BooleanArrayReturning EachStringEqualsScalar(
+        string entity,
+        string fieldName,
+        string value
+    )
+    {
+        return new BooleanArrayReturning(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(new StringField(entity, fieldName)),
+                    OneOf<StringReturning, StringArrayReturning>.FromT0(
+                        new StringReturning(new StringScalar(value))
+                    )
+                )
+            )
+        );
+    }
+
+    internal static OrderByItem OrderByString(
+        string entity,
+        string fieldName,
+        SortDirection direction = SortDirection.Asc
+    )
+    {
+        return new OrderByItem(
+            new Field(new StringField(entity, fieldName)),
+            direction
+        );
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionEachExtendedTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionEachExtendedTests.cs
@@ -1,0 +1,538 @@
+using OneOf;
+using Pure.RelationalSchema.Storage.Abstractions;
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Helpers;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachBooleanOperations;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+using Query = PureQL.CSharp.Model.Query;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests;
+
+public sealed record PureQLProjectionEachExtendedTests
+{
+    [Fact]
+    public void EachStringComparisonLessThanFiltersBelowThreshold()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachComparison(
+                        new EachStringComparison(
+                            EachComparisonOperator.EachLessThan,
+                            new StringArrayReturning(
+                                new StringField(s.Entity, s.First.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                new StringReturning(new StringScalar("test3"))
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        // "test0", "test1", "test2" come strictly before "test3"
+        Assert.Equal(3, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void EachStringComparisonGreaterThanOrEqualFiltersInclusively()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachComparison(
+                        new EachStringComparison(
+                            EachComparisonOperator.EachGreaterThanOrEqual,
+                            new StringArrayReturning(
+                                new StringField(s.Entity, s.First.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                new StringReturning(new StringScalar("test7"))
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        // "test7", "test8", "test9"
+        Assert.Equal(3, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void EachStringComparisonLessThanOrEqualIsInclusive()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachComparison(
+                        new EachStringComparison(
+                            EachComparisonOperator.EachLessThanOrEqual,
+                            new StringArrayReturning(
+                                new StringField(s.Entity, s.First.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                new StringReturning(new StringScalar("test2"))
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        // "test0", "test1", "test2"
+        Assert.Equal(3, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void EachAndWithSingleConditionIsIdentity()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachAndOperator(
+                        [
+                            QueryHelpers.EachStringEqualsScalar(
+                                s.Entity,
+                                s.First.Name.TextValue,
+                                "test4"
+                            ),
+                        ]
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        _ = Assert.Single(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void EachAndWithImpossibleConjunctionIsEmpty()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachAndOperator(
+                        [
+                            QueryHelpers.EachStringEqualsScalar(
+                                s.Entity,
+                                s.First.Name.TextValue,
+                                "test1"
+                            ),
+                            QueryHelpers.EachStringEqualsScalar(
+                                s.Entity,
+                                s.First.Name.TextValue,
+                                "test2"
+                            ),
+                        ]
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Empty(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void EachOrWithThreeConditionsUnionsAll()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachOrOperator(
+                        [
+                            QueryHelpers.EachStringEqualsScalar(
+                                s.Entity,
+                                s.First.Name.TextValue,
+                                "test1"
+                            ),
+                            QueryHelpers.EachStringEqualsScalar(
+                                s.Entity,
+                                s.First.Name.TextValue,
+                                "test3"
+                            ),
+                            QueryHelpers.EachStringEqualsScalar(
+                                s.Entity,
+                                s.First.Name.TextValue,
+                                "test5"
+                            ),
+                        ]
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Equal(3, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void EachNotOverEachAndExcludesIntersection()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        BooleanArrayReturning inner = new(
+            new EachAndOperator(
+                [
+                    new BooleanArrayReturning(
+                        new EachComparison(
+                            new EachStringComparison(
+                                EachComparisonOperator.EachGreaterThanOrEqual,
+                                new StringArrayReturning(
+                                    new StringField(s.Entity, s.First.Name.TextValue)
+                                ),
+                                OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                    new StringReturning(new StringScalar("test3"))
+                                )
+                            )
+                        )
+                    ),
+                    new BooleanArrayReturning(
+                        new EachComparison(
+                            new EachStringComparison(
+                                EachComparisonOperator.EachLessThanOrEqual,
+                                new StringArrayReturning(
+                                    new StringField(s.Entity, s.First.Name.TextValue)
+                                ),
+                                OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                    new StringReturning(new StringScalar("test6"))
+                                )
+                            )
+                        )
+                    ),
+                ]
+            )
+        );
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(new EachNotOperator(inner)),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        // Outside [test3, test6] → test0, test1, test2, test7, test8, test9 = 6 rows
+        Assert.Equal(6, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void EachNotOfEachNotIsIdempotent()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        BooleanArrayReturning innerPredicate = QueryHelpers.EachStringEqualsScalar(
+            s.Entity,
+            s.First.Name.TextValue,
+            "test4"
+        );
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachNotOperator(
+                        new BooleanArrayReturning(new EachNotOperator(innerPredicate))
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        _ = Assert.Single(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void EachFieldToFieldGreaterThanReturnsEmptyForIdenticalColumns()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachComparison(
+                        new EachStringComparison(
+                            EachComparisonOperator.EachGreaterThan,
+                            new StringArrayReturning(
+                                new StringField(s.Entity, s.First.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT1(
+                                new StringArrayReturning(
+                                    new StringField(s.Entity, s.Second.Name.TextValue)
+                                )
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        // Both columns hold the same per-row value → no strict-greater rows.
+        Assert.Empty(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void OrderByAscendingExplicitMatchesDefault()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet ascExplicit = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: null,
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy:
+                [
+                    QueryHelpers.OrderByString(
+                        s.Entity,
+                        s.First.Name.TextValue,
+                        SortDirection.Asc
+                    ),
+                ],
+                pagination: null
+            )
+        );
+
+        IStoredTableDataSet ascDefault = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: null,
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy:
+                [QueryHelpers.OrderByString(s.Entity, s.First.Name.TextValue)],
+                pagination: null
+            )
+        );
+
+        Assert.Equal(
+            ascDefault.AsEnumerable().Select(r => r.Cells[s.First].Value.TextValue),
+            ascExplicit.AsEnumerable().Select(r => r.Cells[s.First].Value.TextValue)
+        );
+    }
+
+    [Fact]
+    public void OrderByMultipleColumnsWithMixedDirections()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: null,
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy:
+                [
+                    QueryHelpers.OrderByString(
+                        s.Entity,
+                        s.First.Name.TextValue,
+                        SortDirection.Desc
+                    ),
+                    QueryHelpers.OrderByString(
+                        s.Entity,
+                        s.Second.Name.TextValue,
+                        SortDirection.Asc
+                    ),
+                ],
+                pagination: null
+            )
+        );
+
+        List<string?> first = [.. result
+            .AsEnumerable()
+            .Select(r => r.Cells[s.First].Value.TextValue)];
+
+        Assert.Equal(
+            first.OrderByDescending(x => x, StringComparer.Ordinal),
+            first
+        );
+    }
+
+    [Fact]
+    public void DistinctCombinedWithWhereAndOrderByPreservesUniqueness()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachComparison(
+                        new EachStringComparison(
+                            EachComparisonOperator.EachGreaterThanOrEqual,
+                            new StringArrayReturning(
+                                new StringField(s.Entity, s.First.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                new StringReturning(new StringScalar("test5"))
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy:
+                [
+                    QueryHelpers.OrderByString(
+                        s.Entity,
+                        s.First.Name.TextValue,
+                        SortDirection.Desc
+                    ),
+                ],
+                pagination: null,
+                distinct: true
+            )
+        );
+
+        List<string?> values = [.. result
+            .AsEnumerable()
+            .Select(r => r.Cells[s.First].Value.TextValue)];
+
+        Assert.Equal(5, values.Count); // test5..test9
+        Assert.Equal(values.Distinct(), values);
+        Assert.Equal(
+            values.OrderByDescending(x => x, StringComparer.Ordinal),
+            values
+        );
+    }
+
+    [Fact]
+    public void EachStringEqualityFieldToFieldFollowedByPagination()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanArrayReturning(
+                    new EachEquality(
+                        new EachStringEquality(
+                            new StringArrayReturning(
+                                new StringField(s.Entity, s.First.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT1(
+                                new StringArrayReturning(
+                                    new StringField(s.Entity, s.Second.Name.TextValue)
+                                )
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy:
+                [QueryHelpers.OrderByString(s.Entity, s.First.Name.TextValue)],
+                pagination: new Pagination(2, 3)
+            )
+        );
+
+        List<string?> values = [.. result
+            .AsEnumerable()
+            .Select(r => r.Cells[s.First].Value.TextValue)];
+
+        Assert.Equal(3, values.Count);
+    }
+
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionEachTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionEachTests.cs
@@ -1,0 +1,512 @@
+using OneOf;
+using Pure.RelationalSchema.Abstractions.Column;
+using Pure.RelationalSchema.Abstractions.Schema;
+using Pure.RelationalSchema.Abstractions.Table;
+using Pure.RelationalSchema.Storage.Abstractions;
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Fakes;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachBooleanOperations;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+using Query = PureQL.CSharp.Model.Query;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests;
+
+public sealed record PureQLProjectionEachTests
+{
+    private static (
+        ISchema schema,
+        IStoredSchemaDataSet dataset,
+        ITable table,
+        IColumn first,
+        IColumn second,
+        string schemaName,
+        string tableName,
+        string entity
+    ) Setup()
+    {
+        ISchema schema = new FakeSchema();
+        IStoredSchemaDataSet dataset = new FakeStoredSchemaDataset(schema);
+        ITable table = schema.Tables.First();
+        IColumn first = table.Columns.First();
+        IColumn second = table.Columns.Skip(1).First();
+        string schemaName = schema.Name.TextValue;
+        string tableName = table.Name.TextValue;
+        return (
+            schema,
+            dataset,
+            table,
+            first,
+            second,
+            schemaName,
+            tableName,
+            $"{schemaName}.{tableName}"
+        );
+    }
+
+    [Fact]
+    public void EachStringEqualityFiltersMatchingRows()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: new BooleanArrayReturning(
+                    new EachEquality(
+                        new EachStringEquality(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                new StringReturning(
+                                    new StringScalar("test5")
+                                )
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        _ = Assert.Single(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void EachNotInvertsMatch()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: new BooleanArrayReturning(
+                    new EachNotOperator(
+                        new BooleanArrayReturning(
+                            new EachEquality(
+                                new EachStringEquality(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            s.entity,
+                                            s.first.Name.TextValue
+                                        )
+                                    ),
+                                    OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                        new StringReturning(
+                                            new StringScalar("test5")
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Equal(9, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void EachAndCombinesPredicates()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        BooleanArrayReturning leftPredicate = new(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(s.entity, s.first.Name.TextValue)
+                    ),
+                    OneOf<StringReturning, StringArrayReturning>.FromT0(
+                        new StringReturning(new StringScalar("test5"))
+                    )
+                )
+            )
+        );
+
+        BooleanArrayReturning rightPredicate = new(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(s.entity, s.second.Name.TextValue)
+                    ),
+                    OneOf<StringReturning, StringArrayReturning>.FromT0(
+                        new StringReturning(new StringScalar("test5"))
+                    )
+                )
+            )
+        );
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: new BooleanArrayReturning(
+                    new EachAndOperator([leftPredicate, rightPredicate])
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        _ = Assert.Single(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void EachOrUnionsMatches()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        BooleanArrayReturning leftPredicate = new(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(s.entity, s.first.Name.TextValue)
+                    ),
+                    OneOf<StringReturning, StringArrayReturning>.FromT0(
+                        new StringReturning(new StringScalar("test1"))
+                    )
+                )
+            )
+        );
+
+        BooleanArrayReturning rightPredicate = new(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(s.entity, s.first.Name.TextValue)
+                    ),
+                    OneOf<StringReturning, StringArrayReturning>.FromT0(
+                        new StringReturning(new StringScalar("test2"))
+                    )
+                )
+            )
+        );
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: new BooleanArrayReturning(
+                    new EachOrOperator([leftPredicate, rightPredicate])
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Equal(2, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void EachStringComparisonGreaterThanOrdersByText()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: new BooleanArrayReturning(
+                    new EachComparison(
+                        new EachStringComparison(
+                            EachComparisonOperator.EachGreaterThan,
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                new StringReturning(
+                                    new StringScalar("test7")
+                                )
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Equal(2, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void EachWithEmptyDatasetReturnsEmpty()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: new BooleanArrayReturning(
+                    new EachEquality(
+                        new EachStringEquality(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                new StringReturning(
+                                    new StringScalar("does-not-exist")
+                                )
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Empty(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void EachFieldToFieldEqualityReturnsAllRows()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: new BooleanArrayReturning(
+                    new EachEquality(
+                        new EachStringEquality(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT1(
+                                new StringArrayReturning(
+                                    new StringField(s.entity, s.second.Name.TextValue)
+                                )
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Equal(10, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void OrderByDescendingReversesOrder()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: null,
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy:
+                [
+                    new OrderByItem(
+                        new Field(
+                            new StringField(s.entity, s.first.Name.TextValue)
+                        ),
+                        SortDirection.Desc
+                    ),
+                ],
+                pagination: null
+            )
+        );
+
+        IEnumerable<string?> expected = s
+            .dataset[s.table]
+            .AsEnumerable()
+            .Select(r => r.Cells[s.first].Value.TextValue)
+            .OrderByDescending(x => x, StringComparer.Ordinal);
+
+        Assert.Equal(
+            expected,
+            result.AsEnumerable().Select(r => r.Cells[s.first].Value.TextValue)
+        );
+    }
+
+    [Fact]
+    public void DistinctRemovesDuplicateRows()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: new BooleanArrayReturning(
+                    new EachEquality(
+                        new EachStringEquality(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            ),
+                            OneOf<StringReturning, StringArrayReturning>.FromT0(
+                                new StringReturning(
+                                    new StringScalar("test5")
+                                )
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null,
+                distinct: true
+            )
+        );
+
+        _ = Assert.Single(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void DistinctIsIdentityWhenAllRowsAlreadyDistinct()
+    {
+        (ISchema schema, IStoredSchemaDataSet dataset, ITable table, IColumn first, IColumn second, string schemaName, string tableName, string entity) s = Setup();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.dataset],
+            new Query(
+                new FromExpression(s.entity, s.entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.entity, s.first.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: null,
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null,
+                distinct: true
+            )
+        );
+
+        Assert.Equal(10, result.AsEnumerable().Count());
+    }
+
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionGapsTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionGapsTests.cs
@@ -1,0 +1,214 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Helpers;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.Arithmetics;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.Equalities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Parameters;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+using ModelEquality = PureQL.CSharp.Model.Equality;
+using Query = PureQL.CSharp.Model.Query;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests;
+
+// Tests for the documented execution gaps in EXECUTION_GAPS.md.
+// Each gap is verified to either throw NotSupportedException loudly
+// (so callers can detect it) or to be skipped with a reference to the
+// gap entry that tracks the work needed to enable the test.
+public sealed record PureQLProjectionGapsTests
+{
+    [Fact]
+    public void StringParameterInWhereThrowsNotSupported()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        _ = Assert.Throws<NotSupportedException>(() =>
+            new PureQLProjection(
+                [s.Dataset],
+                new Query(
+                    new FromExpression(s.Entity, s.Entity),
+                    [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                    where: new BooleanReturning(
+                        new ModelEquality(
+                            new SingleValueEquality(
+                                new StringEquality(
+                                    new StringReturning(new StringParameter("p")),
+                                    new StringReturning(new StringScalar("test1"))
+                                )
+                            )
+                        )
+                    ),
+                    join: null,
+                    groupBy: null,
+                    having: null,
+                    orderBy: null,
+                    pagination: null
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void NumberAggregateInsideHavingThrowsNotSupported()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        _ = Assert.Throws<NotSupportedException>(() =>
+            new PureQLProjection(
+                [s.Dataset],
+                new Query(
+                    new FromExpression(s.Entity, s.Entity),
+                    [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                    where: null,
+                    join: null,
+                    groupBy:
+                    [new Field(new StringField(s.Entity, s.First.Name.TextValue))],
+                    having: new BooleanReturning(
+                        new Comparison(
+                            new NumberComparison(
+                                ComparisonOperator.GreaterThan,
+                                new NumberReturning(
+                                    new NumberAggregate(
+                                        new SumNumber(
+                                            new NumberArrayReturning(
+                                                new NumberField(
+                                                    s.Entity,
+                                                    s.First.Name.TextValue
+                                                )
+                                            )
+                                        )
+                                    )
+                                ),
+                                new NumberReturning(new NumberScalar(0))
+                            )
+                        )
+                    ),
+                    orderBy: null,
+                    pagination: null
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void CountInsideHavingThrowsNotSupported()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        _ = Assert.Throws<NotSupportedException>(() =>
+            new PureQLProjection(
+                [s.Dataset],
+                new Query(
+                    new FromExpression(s.Entity, s.Entity),
+                    [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                    where: null,
+                    join: null,
+                    groupBy:
+                    [new Field(new StringField(s.Entity, s.First.Name.TextValue))],
+                    having: new BooleanReturning(
+                        new Comparison(
+                            new NumberComparison(
+                                ComparisonOperator.GreaterThan,
+                                new NumberReturning(
+                                    new Count(
+                                        new ArrayReturning(
+                                            new StringArrayReturning(
+                                                new StringField(
+                                                    s.Entity,
+                                                    s.First.Name.TextValue
+                                                )
+                                            )
+                                        )
+                                    )
+                                ),
+                                new NumberReturning(new NumberScalar(1))
+                            )
+                        )
+                    ),
+                    orderBy: null,
+                    pagination: null
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void SingleValueArithmeticInsideWhereThrowsNotSupported()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        _ = Assert.Throws<NotSupportedException>(() =>
+            new PureQLProjection(
+                [s.Dataset],
+                new Query(
+                    new FromExpression(s.Entity, s.Entity),
+                    [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                    where: new BooleanReturning(
+                        new ModelEquality(
+                            new SingleValueEquality(
+                                new NumberEquality(
+                                    new NumberReturning(
+                                        new Arithmetic(
+                                            new Add(
+                                                [
+                                                    new NumberReturning(
+                                                        new NumberScalar(1)
+                                                    ),
+                                                    new NumberReturning(
+                                                        new NumberScalar(2)
+                                                    ),
+                                                ]
+                                            )
+                                        )
+                                    ),
+                                    new NumberReturning(new NumberScalar(3))
+                                )
+                            )
+                        )
+                    ),
+                    join: null,
+                    groupBy: null,
+                    having: null,
+                    orderBy: null,
+                    pagination: null
+                )
+            )
+        );
+    }
+
+#pragma warning disable xUnit1004 // Pending execution gaps — see EXECUTION_GAPS.md
+    [Fact(Skip = "Computed-column select projections are tracked as Gap 4 "
+        + "in EXECUTION_GAPS.md (sample 17_each_arithmetic_select.json).")]
+    public void ComputedSelectExpressionShouldProjectAsSyntheticColumn()
+    {
+        Assert.Fail("Pending Gap 4");
+    }
+
+    [Fact(Skip = "Real aggregate folding (sum/min/max/avg/count) inside "
+        + "groupBy projection is tracked as Gap 3 in EXECUTION_GAPS.md "
+        + "(samples 06_count_aggregate.json, 07_group_by.json).")]
+    public void AggregateProjectionShouldFoldGroupRows()
+    {
+        Assert.Fail("Pending Gap 3");
+    }
+
+    [Fact(Skip = "Parameter binding throughout the executor is tracked "
+        + "as Gap 1 in EXECUTION_GAPS.md (samples 10_parameters.json, "
+        + "12_complex_query.json).")]
+    public void ParameterBoundWhereShouldFilterByBoundValue()
+    {
+        Assert.Fail("Pending Gap 1");
+    }
+
+    [Fact(Skip = "NullField projection is tracked as Gap 5 in "
+        + "EXECUTION_GAPS.md; depends on Gap 4 being closed first.")]
+    public void NullFieldSelectShouldProduceAllNullColumn()
+    {
+        Assert.Fail("Pending Gap 5 (blocked by Gap 4)");
+    }
+#pragma warning restore xUnit1004
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionJoinEachTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionJoinEachTests.cs
@@ -1,0 +1,164 @@
+using OneOf;
+using Pure.RelationalSchema.Abstractions.Column;
+using Pure.RelationalSchema.Abstractions.Schema;
+using Pure.RelationalSchema.Abstractions.Table;
+using Pure.RelationalSchema.Storage.Abstractions;
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Fakes;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using Query = PureQL.CSharp.Model.Query;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests;
+
+public sealed record PureQLProjectionJoinEachTests
+{
+    private sealed record TwoTableEnv(
+        IStoredSchemaDataSet LeftDataset,
+        IStoredSchemaDataSet RightDataset,
+        ITable LeftTable,
+        ITable RightTable,
+        IColumn LeftCol,
+        IColumn RightCol,
+        string LeftEntity,
+        string RightEntity
+    );
+
+    private static TwoTableEnv NewTwoTableEnv()
+    {
+        ISchema leftSchema = new FakeSchema();
+        ISchema rightSchema = new FakeSchema();
+        IStoredSchemaDataSet left = new FakeStoredSchemaDataset(leftSchema);
+        IStoredSchemaDataSet right = new FakeStoredSchemaDataset(rightSchema);
+        ITable lt = leftSchema.Tables.First();
+        ITable rt = rightSchema.Tables.First();
+        return new TwoTableEnv(
+            left,
+            right,
+            lt,
+            rt,
+            lt.Columns.First(),
+            rt.Columns.First(),
+            $"{leftSchema.Name.TextValue}.{lt.Name.TextValue}",
+            $"{rightSchema.Name.TextValue}.{rt.Name.TextValue}"
+        );
+    }
+
+    [Fact]
+    public void InnerJoinWithEachEqualityOnConditionMatchesByRowValue()
+    {
+        TwoTableEnv s = NewTwoTableEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.LeftDataset, s.RightDataset],
+            new Query(
+                new FromExpression(s.LeftEntity, s.LeftEntity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.LeftEntity, s.LeftCol.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: null,
+                join:
+                [
+                    new Join(
+                        JoinType.Inner,
+                        s.RightEntity,
+                        new BooleanArrayReturning(
+                            new EachEquality(
+                                new EachStringEquality(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            s.LeftEntity,
+                                            s.LeftCol.Name.TextValue
+                                        )
+                                    ),
+                                    OneOf<StringReturning, StringArrayReturning>.FromT1(
+                                        new StringArrayReturning(
+                                            new StringField(
+                                                s.RightEntity,
+                                                s.RightCol.Name.TextValue
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                ],
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        // 10 rows × 10 rows, paired only when row values match.
+        // FakeRows generates "test0".."test9" for every column,
+        // so each left row matches exactly one right row.
+        Assert.Equal(10, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void LeftJoinWithEachEqualityKeepsLeftRowsWithoutMatch()
+    {
+        TwoTableEnv s = NewTwoTableEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.LeftDataset, s.RightDataset],
+            new Query(
+                new FromExpression(s.LeftEntity, s.LeftEntity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(s.LeftEntity, s.LeftCol.Name.TextValue)
+                            )
+                        )
+                    ),
+                ],
+                where: null,
+                join:
+                [
+                    new Join(
+                        JoinType.Left,
+                        s.RightEntity,
+                        new BooleanArrayReturning(
+                            new EachEquality(
+                                new EachStringEquality(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            s.LeftEntity,
+                                            s.LeftCol.Name.TextValue
+                                        )
+                                    ),
+                                    OneOf<StringReturning, StringArrayReturning>.FromT1(
+                                        new StringArrayReturning(
+                                            new StringField(
+                                                s.RightEntity,
+                                                s.RightCol.Name.TextValue
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                ],
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        // Every left row matches exactly one right row → 10 result rows.
+        Assert.Equal(10, result.AsEnumerable().Count());
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionMixedBooleanTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionMixedBooleanTests.cs
@@ -1,0 +1,203 @@
+using Pure.RelationalSchema.Storage.Abstractions;
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Helpers;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.BooleanOperations;
+using PureQL.CSharp.Model.Equalities;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+using ModelEquality = PureQL.CSharp.Model.Equality;
+using Query = PureQL.CSharp.Model.Query;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests;
+
+public sealed record PureQLProjectionMixedBooleanTests
+{
+    [Fact]
+    public void BooleanScalarTrueAcceptsAllRows()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanReturning(new BooleanScalar(true)),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Equal(10, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void BooleanScalarFalseRejectsAllRows()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanReturning(new BooleanScalar(false)),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Empty(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void AndOperatorOverBooleanArrayConditionsIsDispatched()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanReturning(
+                    new BooleanOperator(
+                        new AndOperator(
+                            QueryHelpers.EachStringEqualsScalar(
+                                s.Entity,
+                                s.First.Name.TextValue,
+                                "test4"
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        _ = Assert.Single(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void OrOperatorOverBooleanArrayConditionsIsDispatched()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanReturning(
+                    new BooleanOperator(
+                        new OrOperator(
+                            QueryHelpers.EachStringEqualsScalar(
+                                s.Entity,
+                                s.First.Name.TextValue,
+                                "test4"
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        _ = Assert.Single(result.AsEnumerable());
+    }
+
+    [Fact]
+    public void NotOperatorInvertsBooleanReturning()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet result = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanReturning(
+                    new BooleanOperator(
+                        new NotOperator(new BooleanReturning(new BooleanScalar(false)))
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Equal(10, result.AsEnumerable().Count());
+    }
+
+    [Fact]
+    public void SingleValueEqualityOfTwoStringScalarsActsAsConstantPredicate()
+    {
+        TestEnvironment s = QueryHelpers.NewEnv();
+
+        IStoredTableDataSet matchingResult = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanReturning(
+                    new ModelEquality(
+                        new SingleValueEquality(
+                            new StringEquality(
+                                new StringReturning(new StringScalar("a")),
+                                new StringReturning(new StringScalar("a"))
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        IStoredTableDataSet mismatchedResult = new PureQLProjection(
+            [s.Dataset],
+            new Query(
+                new FromExpression(s.Entity, s.Entity),
+                [QueryHelpers.SelectStringField(s.Entity, s.First.Name.TextValue)],
+                where: new BooleanReturning(
+                    new ModelEquality(
+                        new SingleValueEquality(
+                            new StringEquality(
+                                new StringReturning(new StringScalar("a")),
+                                new StringReturning(new StringScalar("b"))
+                            )
+                        )
+                    )
+                ),
+                join: null,
+                groupBy: null,
+                having: null,
+                orderBy: null,
+                pagination: null
+            )
+        );
+
+        Assert.Equal(10, matchingResult.AsEnumerable().Count());
+        Assert.Empty(mismatchedResult.AsEnumerable());
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionWhereOrderByPaginationTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/PureQLProjectionWhereOrderByPaginationTests.cs
@@ -468,10 +468,12 @@ public sealed record PureQlProjectionWhereOrderByPaginationTests
                 having: null,
                 orderBy:
                 [
-                    new Field(
-                        new StringField(
-                            $"{schemaName}.{tableName}",
-                            firstColumn.Name.TextValue
+                    new OrderByItem(
+                        new Field(
+                            new StringField(
+                                $"{schemaName}.{tableName}",
+                                firstColumn.Name.TextValue
+                            )
                         )
                     ),
                 ],
@@ -538,8 +540,10 @@ public sealed record PureQlProjectionWhereOrderByPaginationTests
                 join: null,
                 groupBy: null,
                 having: null,
-                orderBy: columnsToSelect.Select(x => new Field(
-                    new StringField($"{schemaName}.{tableName}", x.Name.TextValue)
+                orderBy: columnsToSelect.Select(x => new OrderByItem(
+                    new Field(
+                        new StringField($"{schemaName}.{tableName}", x.Name.TextValue)
+                    )
                 )),
                 pagination: null
             )
@@ -699,10 +703,12 @@ public sealed record PureQlProjectionWhereOrderByPaginationTests
                 having: null,
                 orderBy:
                 [
-                    new Field(
-                        new StringField(
-                            $"{schemaName}.{tableName}",
-                            firstColumn.Name.TextValue
+                    new OrderByItem(
+                        new Field(
+                            new StringField(
+                                $"{schemaName}.{tableName}",
+                                firstColumn.Name.TextValue
+                            )
                         )
                     ),
                 ],

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/WhereExpressionBuilderHelperTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/WhereExpressionBuilderHelperTests.cs
@@ -1,0 +1,274 @@
+using System.Reflection;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests;
+
+// Direct unit tests for the small nullable arithmetic helpers inside
+// WhereExpressionBuilder. These helpers are reached only via compiled
+// expression trees in production, so exercising them directly raises
+// branch coverage of null-propagation paths to 100%.
+public sealed record WhereExpressionBuilderHelperTests
+{
+    private static readonly Type Builder = typeof(PureQLProjection)
+        .Assembly.GetType(
+            "Pure.RelationalSchema.Storage.PureQL.Projection.WhereExpressionBuilder"
+        )!;
+
+    private static T? Invoke<T>(string name, params object?[] args)
+        where T : struct
+    {
+        MethodInfo m = Builder.GetMethod(
+            name,
+            BindingFlags.Static | BindingFlags.NonPublic
+        )!;
+        return (T?)m.Invoke(null, args);
+    }
+
+    [Theory]
+    [InlineData(2.0, 3.0, 5.0)]
+    [InlineData(-1.5, 1.5, 0.0)]
+    public void AddDoublesAddsValues(double a, double b, double expected)
+    {
+        Assert.Equal(expected, Invoke<double>("AddDoubles", a, b));
+    }
+
+    [Fact]
+    public void AddDoublesReturnsNullIfLeftIsNull()
+    {
+        Assert.Null(Invoke<double>("AddDoubles", null, 1.0));
+    }
+
+    [Fact]
+    public void AddDoublesReturnsNullIfRightIsNull()
+    {
+        Assert.Null(Invoke<double>("AddDoubles", 1.0, null));
+    }
+
+    [Theory]
+    [InlineData(10.0, 3.0, 7.0)]
+    [InlineData(0.0, 5.0, -5.0)]
+    public void SubtractDoublesSubtractsValues(double a, double b, double expected)
+    {
+        Assert.Equal(expected, Invoke<double>("SubtractDoubles", a, b));
+    }
+
+    [Fact]
+    public void SubtractDoublesPropagatesNull()
+    {
+        Assert.Null(Invoke<double>("SubtractDoubles", null, 1.0));
+        Assert.Null(Invoke<double>("SubtractDoubles", 1.0, null));
+    }
+
+    [Theory]
+    [InlineData(2.0, 3.0, 6.0)]
+    [InlineData(0.0, 5.0, 0.0)]
+    public void MultiplyDoublesMultipliesValues(double a, double b, double expected)
+    {
+        Assert.Equal(expected, Invoke<double>("MultiplyDoubles", a, b));
+    }
+
+    [Fact]
+    public void MultiplyDoublesPropagatesNull()
+    {
+        Assert.Null(Invoke<double>("MultiplyDoubles", null, 1.0));
+        Assert.Null(Invoke<double>("MultiplyDoubles", 1.0, null));
+    }
+
+    [Theory]
+    [InlineData(10.0, 2.0, 5.0)]
+    [InlineData(7.5, 2.5, 3.0)]
+    public void DivideDoublesDividesValues(double a, double b, double expected)
+    {
+        Assert.Equal(expected, Invoke<double>("DivideDoubles", a, b));
+    }
+
+    [Fact]
+    public void DivideDoublesByZeroReturnsNull()
+    {
+        Assert.Null(Invoke<double>("DivideDoubles", 1.0, 0.0));
+    }
+
+    [Fact]
+    public void DivideDoublesPropagatesNull()
+    {
+        Assert.Null(Invoke<double>("DivideDoubles", null, 1.0));
+        Assert.Null(Invoke<double>("DivideDoubles", 1.0, null));
+    }
+
+    [Fact]
+    public void AddDaysAdvancesDateByGivenDays()
+    {
+        DateOnly? result = Invoke<DateOnly>(
+            "AddDays",
+            new DateOnly(2026, 1, 1),
+            5.0
+        );
+        Assert.Equal(new DateOnly(2026, 1, 6), result);
+    }
+
+    [Fact]
+    public void AddDaysWithNegativeNumberMovesBackwards()
+    {
+        DateOnly? result = Invoke<DateOnly>(
+            "AddDays",
+            new DateOnly(2026, 1, 10),
+            -3.0
+        );
+        Assert.Equal(new DateOnly(2026, 1, 7), result);
+    }
+
+    [Fact]
+    public void AddDaysPropagatesNull()
+    {
+        Assert.Null(Invoke<DateOnly>("AddDays", null, 1.0));
+        Assert.Null(Invoke<DateOnly>("AddDays", new DateOnly(2026, 1, 1), null));
+    }
+
+    [Fact]
+    public void DiffDaysReturnsPositiveWhenLeftIsLater()
+    {
+        Assert.Equal(
+            10.0,
+            Invoke<double>(
+                "DiffDays",
+                new DateOnly(2026, 1, 15),
+                new DateOnly(2026, 1, 5)
+            )
+        );
+    }
+
+    [Fact]
+    public void DiffDaysReturnsNegativeWhenLeftIsEarlier()
+    {
+        Assert.Equal(
+            -10.0,
+            Invoke<double>(
+                "DiffDays",
+                new DateOnly(2026, 1, 5),
+                new DateOnly(2026, 1, 15)
+            )
+        );
+    }
+
+    [Fact]
+    public void DiffDaysReturnsZeroForSameDate()
+    {
+        Assert.Equal(
+            0.0,
+            Invoke<double>(
+                "DiffDays",
+                new DateOnly(2026, 3, 7),
+                new DateOnly(2026, 3, 7)
+            )
+        );
+    }
+
+    [Fact]
+    public void DiffDaysPropagatesNull()
+    {
+        Assert.Null(Invoke<double>("DiffDays", null, new DateOnly(2026, 1, 1)));
+        Assert.Null(Invoke<double>("DiffDays", new DateOnly(2026, 1, 1), null));
+    }
+
+    [Fact]
+    public void AddSecondsToTimeAdvancesByGivenSeconds()
+    {
+        TimeOnly? result = Invoke<TimeOnly>(
+            "AddSecondsToTime",
+            new TimeOnly(10, 0, 0),
+            90.0
+        );
+        Assert.Equal(new TimeOnly(10, 1, 30), result);
+    }
+
+    [Fact]
+    public void AddSecondsToTimePropagatesNull()
+    {
+        Assert.Null(Invoke<TimeOnly>("AddSecondsToTime", null, 1.0));
+        Assert.Null(Invoke<TimeOnly>(
+            "AddSecondsToTime",
+            new TimeOnly(0, 0, 0),
+            null
+        ));
+    }
+
+    [Fact]
+    public void DiffSecondsTimeReturnsPositiveWhenLeftIsLater()
+    {
+        Assert.Equal(
+            90.0,
+            Invoke<double>(
+                "DiffSecondsTime",
+                new TimeOnly(10, 1, 30),
+                new TimeOnly(10, 0, 0)
+            )
+        );
+    }
+
+    [Fact]
+    public void DiffSecondsTimePropagatesNull()
+    {
+        Assert.Null(Invoke<double>(
+            "DiffSecondsTime",
+            null,
+            new TimeOnly(0, 0, 0)
+        ));
+        Assert.Null(Invoke<double>(
+            "DiffSecondsTime",
+            new TimeOnly(0, 0, 0),
+            null
+        ));
+    }
+
+    [Fact]
+    public void AddSecondsToDateTimeAdvancesByGivenSeconds()
+    {
+        DateTime? result = Invoke<DateTime>(
+            "AddSecondsToDateTime",
+            new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc),
+            3600.0
+        );
+        Assert.Equal(
+            new DateTime(2026, 1, 1, 13, 0, 0, DateTimeKind.Utc),
+            result
+        );
+    }
+
+    [Fact]
+    public void AddSecondsToDateTimePropagatesNull()
+    {
+        Assert.Null(Invoke<DateTime>("AddSecondsToDateTime", null, 1.0));
+        Assert.Null(Invoke<DateTime>(
+            "AddSecondsToDateTime",
+            DateTime.UnixEpoch,
+            null
+        ));
+    }
+
+    [Fact]
+    public void DiffSecondsDateTimeReturnsLeftMinusRight()
+    {
+        Assert.Equal(
+            3600.0,
+            Invoke<double>(
+                "DiffSecondsDateTime",
+                new DateTime(2026, 1, 1, 13, 0, 0, DateTimeKind.Utc),
+                new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc)
+            )
+        );
+    }
+
+    [Fact]
+    public void DiffSecondsDateTimePropagatesNull()
+    {
+        Assert.Null(Invoke<double>(
+            "DiffSecondsDateTime",
+            null,
+            DateTime.UnixEpoch
+        ));
+        Assert.Null(Invoke<double>(
+            "DiffSecondsDateTime",
+            DateTime.UnixEpoch,
+            null
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

- Bumps `PureQL.CSharp.Model` from `0.1.0-preview.10.0.0` to `0.1.0-preview.11.0.0`, tracking PureQL specification `0.1.0-preview.0.5.0`.
- Implements the per-row `each*` operator family (`EachEquality`, `EachComparison`, `EachAnd`/`Or`/`Not`, `EachArithmetic`, `EachDateAddDays`/`DiffDays`, `EachTimeAddSeconds`/`DiffSeconds`, `EachDateTimeAddSeconds`/`DiffSeconds`) inside `Where` and `Join.On`, with both broadcast and zip operand modes.
- Wires up `OrderByItem` / `SortDirection` (ASC/DESC), the new `Query.Distinct` flag, and the widened `Where` / `Join.On` `OneOf<BooleanReturning, BooleanArrayReturning>` shapes.
- Adds `DistinctApplicator`, extends `OrderByApplicator` / `GroupByApplicator` for the new `NullField` arm, and adds exhaustive `Match` arms for the widened `*Returning` unions.
- Test suite grows **23 → 106 tests** (+83): per-row `each*` semantics, sort direction, distinct, join-with-each-on, mixed boolean/arrayBoolean dispatch, direct unit tests for every nullable arithmetic helper and cell-value extractor, plus `NotSupportedException` assertions for documented executor gaps.
- Documents executor surface in `CHANGELOG.md` (new version `0.1.0-preview.2.0.0`) and updates `README.md` / `CLAUDE.md`.

## Test plan

- [x] `dotnet build --no-restore -warnaserror` — 0 warnings, 0 errors (net8.0 / net9.0 / net10.0).
- [x] `dotnet format --verify-no-changes` — clean.
- [x] `dotnet test --no-build` — 102 passing, 4 skipped (documented gaps), 0 failed.
- [x] CI: confirm coverage threshold (≥52%, warn at 99%) is met.
- [x] CI: confirm mutation threshold (≥32%) is met.