### PR TITLE
Baseline updated

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/Pure.RelationalSchema.Storage.PureQL.Projection.csproj
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/Pure.RelationalSchema.Storage.PureQL.Projection.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>false</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.2.0.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.2.0.1</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Storage.PureQL.Projection</PackageId>


### PR DESCRIPTION
Bumps `PackageValidationBaselineVersion` to `0.1.0-preview.2.0.1` following the release of that version.