### PR TITLE
Add reproduction tests for joined-column resolution bugs (#77, #78)

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/CollidingNameDatabase.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/CollidingNameDatabase.cs
@@ -1,0 +1,247 @@
+using Pure.RelationalSchema.Abstractions.Column;
+using Pure.RelationalSchema.Abstractions.Schema;
+using Pure.RelationalSchema.Abstractions.Table;
+using Pure.RelationalSchema.ColumnType;
+using Pure.RelationalSchema.HashCodes;
+using Pure.RelationalSchema.Storage.Abstractions;
+using String = Pure.Primitives.String.String;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+
+// A multi-schema dataset where every table carries a same-named primary-key
+// column ("id") — the shape of any real schema that uses a conventional PK
+// name. This deliberately violates SampleDatabase's globally-unique-name
+// invariant to reproduce the joined-column resolution bugs of issues #77 and
+// #78: planner.needs joins to refs.specialties (needs.spec_id -> specialties.id)
+// and to billing.estimates (needs.id -> estimates.need_id, 1:1).
+internal sealed class CollidingNameDatabase
+{
+    public const string PlannerSchemaName = "planner";
+    public const string RefsSchemaName = "refs";
+    public const string BillingSchemaName = "billing";
+
+    public static class Needs
+    {
+        public const string TableName = "needs";
+        public const string Entity = "planner.needs";
+        public const string Id = "id";
+        public const string SpecialtyId = "spec_id";
+        public const string PlannedHours = "planned_hours";
+    }
+
+    public static class Specialties
+    {
+        public const string TableName = "specialties";
+        public const string Entity = "refs.specialties";
+        public const string Id = "id";
+        public const string Title = "title";
+    }
+
+    public static class Estimates
+    {
+        public const string TableName = "estimates";
+        public const string Entity = "billing.estimates";
+        public const string Id = "id";
+        public const string NeedId = "need_id";
+        public const string Status = "estimate_status";
+        public const string ActualHours = "actual_hours";
+    }
+
+    private static readonly IReadOnlyList<IColumn> NeedColumns =
+    [
+        new Column.Column(new String(Needs.Id), new UuidColumnType()),
+        new Column.Column(new String(Needs.SpecialtyId), new UuidColumnType()),
+        new Column.Column(new String(Needs.PlannedHours), new DoubleColumnType()),
+    ];
+
+    private static readonly IReadOnlyList<IColumn> SpecialtyColumns =
+    [
+        new Column.Column(new String(Specialties.Id), new UuidColumnType()),
+        new Column.Column(new String(Specialties.Title), new StringColumnType()),
+    ];
+
+    private static readonly IReadOnlyList<IColumn> EstimateColumns =
+    [
+        new Column.Column(new String(Estimates.Id), new UuidColumnType()),
+        new Column.Column(new String(Estimates.NeedId), new UuidColumnType()),
+        new Column.Column(new String(Estimates.Status), new StringColumnType()),
+        new Column.Column(new String(Estimates.ActualHours), new DoubleColumnType()),
+    ];
+
+    private readonly IReadOnlyList<IStoredSchemaDataSet> _datasets;
+
+    public CollidingNameDatabase()
+    {
+        ITable needsTable = new Table.Table(
+            new String(Needs.TableName),
+            NeedColumns,
+            []
+        );
+        ITable specialtiesTable = new Table.Table(
+            new String(Specialties.TableName),
+            SpecialtyColumns,
+            []
+        );
+        ITable estimatesTable = new Table.Table(
+            new String(Estimates.TableName),
+            EstimateColumns,
+            []
+        );
+
+        _datasets =
+        [
+            SchemaDataset(
+                PlannerSchemaName,
+                new SampleTableDataset(needsTable, BuildNeedRows())
+            ),
+            SchemaDataset(
+                RefsSchemaName,
+                new SampleTableDataset(specialtiesTable, BuildSpecialtyRows())
+            ),
+            SchemaDataset(
+                BillingSchemaName,
+                new SampleTableDataset(estimatesTable, BuildEstimateRows())
+            ),
+        ];
+    }
+
+    public IEnumerable<IStoredSchemaDataSet> Datasets => _datasets;
+
+    // Three referenced specialties plus one ("Rigger") no need points at.
+    public IReadOnlyList<SpecialtyRow> SpecialtyRows { get; } = [
+        new(Id(501), "Welder"),
+        new(Id(502), "Fitter"),
+        new(Id(503), "Painter"),
+        new(Id(504), "Rigger"),
+    ];
+
+    // Six needs across three specialties; the need's own PK never equals any
+    // specialty PK, so a query that confuses the two produces detectably
+    // different values.
+    public IReadOnlyList<NeedRow> NeedRows { get; } = [
+        new(Id(1), Id(501), 10),
+        new(Id(2), Id(501), 20),
+        new(Id(3), Id(502), 30),
+        new(Id(4), Id(502), 40),
+        new(Id(5), Id(502), 50),
+        new(Id(6), Id(503), 60),
+    ];
+
+    // One estimate per need (1:1), the shape of issue #78's fact table.
+    public IReadOnlyList<EstimateRow> EstimateRows { get; } = [
+        new(Id(601), Id(1), "draft", 12),
+        new(Id(602), Id(2), "final", 18),
+        new(Id(603), Id(3), "draft", 33),
+        new(Id(604), Id(4), "final", 41),
+        new(Id(605), Id(5), "draft", 47),
+        new(Id(606), Id(6), "final", 66),
+    ];
+
+    private static Guid Id(int seed)
+    {
+        return new Guid(seed, 0, 0, new byte[8]);
+    }
+
+    private static IStoredSchemaDataSet SchemaDataset(
+        string schemaName,
+        SampleTableDataset tableDataset
+    )
+    {
+        ISchema schema = new Schema.Schema(
+            new String(schemaName),
+            [tableDataset.TableSchema],
+            []
+        );
+
+        IReadOnlyDictionary<ITable, IStoredTableDataSet> datasetsByTable =
+            new Collections.Generic.Dictionary<
+                IStoredTableDataSet,
+                ITable,
+                IStoredTableDataSet
+            >(
+                [tableDataset],
+                dataset => dataset.TableSchema,
+                dataset => dataset,
+                table => new TableHash(table)
+            );
+
+        return new StoredSchemaDataset(schema, datasetsByTable);
+    }
+
+    private IReadOnlyList<IRow> BuildNeedRows()
+    {
+        return
+        [
+            .. NeedRows.Select(need =>
+                BuildRow(
+                    NeedColumns,
+                    new Dictionary<string, string>
+                    {
+                        [Needs.Id] = CellText.From(need.NeedId),
+                        [Needs.SpecialtyId] = CellText.From(need.NeedSpecialtyId),
+                        [Needs.PlannedHours] = CellText.From(need.NeedPlannedHours),
+                    }
+                )
+            ),
+        ];
+    }
+
+    private IReadOnlyList<IRow> BuildSpecialtyRows()
+    {
+        return
+        [
+            .. SpecialtyRows.Select(specialty =>
+                BuildRow(
+                    SpecialtyColumns,
+                    new Dictionary<string, string>
+                    {
+                        [Specialties.Id] = CellText.From(specialty.SpecialtyId),
+                        [Specialties.Title] = CellText.From(
+                            specialty.SpecialtyTitle
+                        ),
+                    }
+                )
+            ),
+        ];
+    }
+
+    private IReadOnlyList<IRow> BuildEstimateRows()
+    {
+        return
+        [
+            .. EstimateRows.Select(estimate =>
+                BuildRow(
+                    EstimateColumns,
+                    new Dictionary<string, string>
+                    {
+                        [Estimates.Id] = CellText.From(estimate.EstimateId),
+                        [Estimates.NeedId] = CellText.From(
+                            estimate.EstimateNeedId
+                        ),
+                        [Estimates.Status] = CellText.From(
+                            estimate.EstimateStatus
+                        ),
+                        [Estimates.ActualHours] = CellText.From(
+                            estimate.EstimateActualHours
+                        ),
+                    }
+                )
+            ),
+        ];
+    }
+
+    private static IRow BuildRow(
+        IEnumerable<IColumn> columns,
+        IReadOnlyDictionary<string, string> textByName
+    )
+    {
+        return new Row(
+            new Collections.Generic.Dictionary<IColumn, IColumn, ICell>(
+                columns,
+                column => column,
+                column => new Cell(new String(textByName[column.Name.TextValue])),
+                column => new ColumnHash(column)
+            )
+        );
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/CollidingNameRecords.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/CollidingNameRecords.cs
@@ -1,0 +1,20 @@
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+
+// Ground-truth mirror of the colliding-name dataset, using real .NET types.
+// Tests compute expected results independently from these records, never by
+// re-deriving from the translator under test.
+
+internal sealed record NeedRow(
+    Guid NeedId,
+    Guid NeedSpecialtyId,
+    double NeedPlannedHours
+);
+
+internal sealed record SpecialtyRow(Guid SpecialtyId, string SpecialtyTitle);
+
+internal sealed record EstimateRow(
+    Guid EstimateId,
+    Guid EstimateNeedId,
+    string EstimateStatus,
+    double EstimateActualHours
+);

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinColumnNameCollisionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinColumnNameCollisionTests.cs
@@ -1,0 +1,231 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
+
+// Reproduces issue #77: when the from table and a joined table both carry a
+// column with the same name (here the conventional PK name "id"), any
+// reference to that name on the joined side — in select, groupBy, or the
+// join's own on clause — must resolve to the joined table's value, not be
+// silently shadowed by the base table's same-named column.
+[Trait("Clause", "Join")]
+[Trait("Feature", "ColumnNameCollision")]
+public sealed class JoinColumnNameCollisionTests
+{
+    private static Join NeedsToSpecialtiesJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            CollidingNameDatabase.Specialties.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.SpecialtyId
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Specialties.Entity,
+                                CollidingNameDatabase.Specialties.Id
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact(
+        Skip = "Issue #77: the join's on clause resolves the joined table's "
+            + "same-named column to the base table's value."
+    )]
+    public void JoinOnClauseWithSameNamedColumnMatchesJoinedTableValues()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.PlannedHours
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [NeedsToSpecialtiesJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expected = NeedRowsJoinedToSpecialties(db).Count();
+
+        Assert.Equal(expected, result.Count);
+    }
+
+    [Fact(
+        Skip = "Issue #77: selecting the joined table's same-named column "
+            + "returns the base table's value instead."
+    )]
+    public void SelectOfSameNamedColumnFromJoinedTableReturnsItsValues()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Specialties.Entity,
+                                CollidingNameDatabase.Specialties.Id
+                            )
+                        )
+                    ),
+                    "spec_pk"
+                ),
+            ],
+            where: null,
+            [NeedsToSpecialtiesJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. NeedRowsJoinedToSpecialties(db)
+                .Select(pair => pair.Specialty.SpecialtyId.ToString())
+                .OrderBy(id => id),
+        ];
+
+        string?[] actual = [.. result.Column("spec_pk").OrderBy(id => id)];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(
+        Skip = "Issue #77: grouping by the joined table's same-named column "
+            + "groups by the base table's value instead."
+    )]
+    public void GroupByOfSameNamedColumnFromJoinedTableGroupsByItsValues()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Specialties.Entity,
+                                CollidingNameDatabase.Specialties.Id
+                            )
+                        )
+                    ),
+                    "spec_pk"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            CollidingNameDatabase.Needs.Entity,
+                                            CollidingNameDatabase
+                                                .Needs
+                                                .PlannedHours
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "total_hours"
+                ),
+            ],
+            where: null,
+            [NeedsToSpecialtiesJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        CollidingNameDatabase.Specialties.Entity,
+                        CollidingNameDatabase.Specialties.Id
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string? SpecialtyId, double TotalHours)[] expected =
+        [
+            .. NeedRowsJoinedToSpecialties(db)
+                .GroupBy(pair => pair.Specialty.SpecialtyId)
+                .Select(group =>
+                    (
+                        group.Key.ToString(),
+                        group.Sum(pair => pair.Need.NeedPlannedHours)
+                    )
+                )
+                .OrderBy(group => group.Item1),
+        ];
+
+        (string? SpecialtyId, double? TotalHours)[] actual =
+        [
+            .. result
+                .Rows.Select(row => (row["spec_pk"], row.Double("total_hours")))
+                .OrderBy(row => row.Item1),
+        ];
+
+        Assert.Equal(expected.Length, result.Count);
+        Assert.Equal(
+            expected,
+            actual.Select(row => (row.SpecialtyId, row.TotalHours ?? 0)).ToArray()
+        );
+    }
+
+    private static IEnumerable<(NeedRow Need, SpecialtyRow Specialty)>
+        NeedRowsJoinedToSpecialties(CollidingNameDatabase db)
+    {
+        return
+            from need in db.NeedRows
+            join specialty in db.SpecialtyRows
+                on need.NeedSpecialtyId equals specialty.SpecialtyId
+            select (need, specialty);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinColumnNameCollisionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinColumnNameCollisionTests.cs
@@ -17,6 +17,7 @@ namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
 // silently shadowed by the base table's same-named column.
 [Trait("Clause", "Join")]
 [Trait("Feature", "ColumnNameCollision")]
+[Trait("Status", "KnownGap")]
 public sealed class JoinColumnNameCollisionTests
 {
     private static Join NeedsToSpecialtiesJoin()

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinedTableColumnProjectionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinedTableColumnProjectionTests.cs
@@ -214,6 +214,7 @@ public sealed class JoinedTableColumnProjectionTests
             + "columns entirely, so projecting one throws KeyNotFoundException "
             + "instead of yielding null cells."
     )]
+    [Trait("Status", "KnownGap")]
     public void LeftJoinUnmatchedRowsExposeJoinedColumnsAsNullCells()
     {
         CollidingNameDatabase db = new CollidingNameDatabase();
@@ -281,6 +282,7 @@ public sealed class JoinedTableColumnProjectionTests
             + "KeyNotFoundException when a group's rows come from the "
             + "unmatched outer-join fallback."
     )]
+    [Trait("Status", "KnownGap")]
     public void LeftJoinGroupByJoinedColumnPutsUnmatchedRowsInNullGroup()
     {
         CollidingNameDatabase db = new CollidingNameDatabase();

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinedTableColumnProjectionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinedTableColumnProjectionTests.cs
@@ -1,0 +1,363 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
+
+// Reproduces issue #78: a select item that references a joined-table column
+// whose name does NOT collide with any base-table column must still see that
+// column after the join — plainly projected, aggregated over the whole set,
+// or used as a groupBy key. The joining tables share the PK name "id" (the
+// shape of the reported schema), but the referenced columns themselves
+// ("actual_hours", "estimate_status") are unique to the joined table.
+//
+// The inner-join tests transcribe the issue's repro steps directly. The
+// left-join tests pin the one in-library path that produces the reported
+// symptoms (KeyNotFoundException from projection / silently empty
+// aggregates): unmatched outer-join rows pass through unmerged, without the
+// joined table's columns, instead of carrying null cells for them.
+[Trait("Clause", "Join")]
+[Trait("Feature", "JoinedColumnProjection")]
+public sealed class JoinedTableColumnProjectionTests
+{
+    private static Join NeedsToEstimatesJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            CollidingNameDatabase.Estimates.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Estimates.Entity,
+                                CollidingNameDatabase.Estimates.NeedId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void SelectOfNonCollidingJoinedColumnReturnsItsValues()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                CollidingNameDatabase.Estimates.Entity,
+                                CollidingNameDatabase.Estimates.ActualHours
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [NeedsToEstimatesJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double[] expected =
+        [
+            .. NeedRowsJoinedToEstimates(db)
+                .Select(pair => pair.Estimate.EstimateActualHours)
+                .OrderBy(hours => hours),
+        ];
+
+        double?[] actual =
+        [
+            .. result
+                .Rows.Select(row =>
+                    row.Double(CollidingNameDatabase.Estimates.ActualHours)
+                )
+                .OrderBy(hours => hours),
+        ];
+
+        Assert.Equal(expected.Length, result.Count);
+        Assert.Equal(expected, actual.Select(hours => hours ?? 0).ToArray());
+    }
+
+    [Fact]
+    public void WholeSetSumOverNonCollidingJoinedColumnComputesTheSum()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            CollidingNameDatabase
+                                                .Estimates
+                                                .Entity,
+                                            CollidingNameDatabase
+                                                .Estimates
+                                                .ActualHours
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "actual_hours_sum"
+                ),
+            ],
+            where: null,
+            [NeedsToEstimatesJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double expected = NeedRowsJoinedToEstimates(db)
+            .Sum(pair => pair.Estimate.EstimateActualHours);
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expected, result.Row(0).Double("actual_hours_sum"));
+    }
+
+    [Fact]
+    public void GroupByNonCollidingJoinedStringColumnGroupsByItsValues()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                CollidingNameDatabase.Estimates.Entity,
+                                CollidingNameDatabase.Estimates.Status
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [NeedsToEstimatesJoin()],
+            [
+                new Field(
+                    new StringField(
+                        CollidingNameDatabase.Estimates.Entity,
+                        CollidingNameDatabase.Estimates.Status
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. NeedRowsJoinedToEstimates(db)
+                .Select(pair => pair.Estimate.EstimateStatus)
+                .Distinct()
+                .OrderBy(status => status),
+        ];
+
+        string?[] actual =
+        [
+            .. result
+                .Column(CollidingNameDatabase.Estimates.Status)
+                .OrderBy(status => status),
+        ];
+
+        Assert.Equal(expected.Length, result.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact(
+        Skip = "Issue #78: unmatched outer-join rows lack the joined table's "
+            + "columns entirely, so projecting one throws KeyNotFoundException "
+            + "instead of yielding null cells."
+    )]
+    public void LeftJoinUnmatchedRowsExposeJoinedColumnsAsNullCells()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Specialties.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.PlannedHours
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [SpecialtiesToNeedsLeftJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int matched = db.NeedRows.Count;
+        int unmatched = db.SpecialtyRows.Count(specialty =>
+            db.NeedRows.All(need => need.NeedSpecialtyId != specialty.SpecialtyId)
+        );
+
+        double[] expectedHours =
+        [
+            .. db.NeedRows
+                .Select(need => need.NeedPlannedHours)
+                .OrderBy(hours => hours),
+        ];
+
+        double?[] cells =
+        [
+            .. result.Rows.Select(row =>
+                row.Double(CollidingNameDatabase.Needs.PlannedHours)
+            ),
+        ];
+
+        double[] actualHours =
+        [
+            .. cells
+                .Where(hours => hours is not null)
+                .Select(hours => hours!.Value)
+                .OrderBy(hours => hours),
+        ];
+
+        Assert.Equal(matched + unmatched, result.Count);
+        Assert.Equal(expectedHours, actualHours);
+        Assert.Equal(unmatched, cells.Count(hours => hours is null));
+    }
+
+    [Fact(
+        Skip = "Issue #78: grouping by a joined column crashes with "
+            + "KeyNotFoundException when a group's rows come from the "
+            + "unmatched outer-join fallback."
+    )]
+    public void LeftJoinGroupByJoinedColumnPutsUnmatchedRowsInNullGroup()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Specialties.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.SpecialtyId
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [SpecialtiesToNeedsLeftJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        CollidingNameDatabase.Needs.Entity,
+                        CollidingNameDatabase.Needs.SpecialtyId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedGroups =
+            db.NeedRows.Select(need => need.NeedSpecialtyId).Distinct().Count()
+            + 1;
+
+        Assert.Equal(expectedGroups, result.Count);
+    }
+
+    private static Join SpecialtiesToNeedsLeftJoin()
+    {
+        return new Join(
+            JoinType.Left,
+            CollidingNameDatabase.Needs.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Specialties.Entity,
+                                CollidingNameDatabase.Specialties.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.SpecialtyId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static IEnumerable<(NeedRow Need, EstimateRow Estimate)>
+        NeedRowsJoinedToEstimates(CollidingNameDatabase db)
+    {
+        return
+            from need in db.NeedRows
+            join estimate in db.EstimateRows
+                on need.NeedId equals estimate.EstimateNeedId
+            select (need, estimate);
+    }
+}


### PR DESCRIPTION
## Summary

Adds executable reproductions for #77 and #78, plus the fixture they need: `CollidingNameDatabase`, a three-schema dataset (`planner.needs`, `refs.specialties`, `billing.estimates`) where **every table carries a same-named `id` PK column** — the shape of any real schema using a conventional PK name. The existing `SampleDatabase` keeps all column names globally unique by design, so it cannot exercise these bugs.

All reproduction tests assert the spec-correct behaviour and are marked `[Fact(Skip = ...)]` per the repo convention for known translator gaps (with the established `#pragma warning disable xUnit1004`), so CI stays green. Removing a Skip turns the corresponding test into the acceptance test for the fix.

## Issue #77 — `JoinColumnNameCollisionTests` (3 tests, all red without Skip)

Confirmed: field references resolve by bare column name (`field.Entity` is discarded end-to-end) and `JoinApplicator.MergeRows` drops same-named right-hand columns.

- `JoinOnClauseWithSameNamedColumnMatchesJoinedTableValues` — the join's own `on` clause is affected: `specialties.id` resolves to the merged row's (base table's) `id`, so the condition compares `needs.spec_id` to `needs.id` and, at HEAD, the inner join returns **0 rows** (expected 6).
- `SelectOfSameNamedColumnFromJoinedTableReturnsItsValues` — selecting `specialties.id` through the join never yields the specialty PKs.
- `GroupByOfSameNamedColumnFromJoinedTableGroupsByItsValues` — grouping by `specialties.id` never produces one group per specialty.

## Issue #78 — `JoinedTableColumnProjectionTests` (3 green + 2 red)

Triage finding: the issue's inner-join repro steps, transcribed 1:1 against in-memory datasets (same shape: shared `id` PK name, non-colliding `actual_hours` / `estimate_status`), **pass at HEAD** — and the library source is byte-identical between HEAD and the published `0.1.0-preview.2.1.1` tag (only the package-validation baseline differs). So the filed inner-join scenario does not lose non-colliding joined columns inside the library itself; those three tests are included green as regression guards.

The two skipped-red tests pin the one in-library path that produces the reported symptoms *exactly*:

- `LeftJoinUnmatchedRowsExposeJoinedColumnsAsNullCells` — `JoinApplicator.LeftJoin` (and `RightJoin`/`FullJoin`) pass unmatched rows through **unmerged**, without the joined table's columns, instead of padding them with null cells. Plain projection of a joined column then throws `KeyNotFoundException: Row has no column named 'planned_hours'` from `CellValueExtractor.GetRequiredCell` — the same failure mode as the issue's step 2.
- `LeftJoinGroupByJoinedColumnPutsUnmatchedRowsInNullGroup` — with a `groupBy`, the crash surfaces through `GroupByApplicator.ProjectionItemOf` line 87 — the **identical stack trace** cited in the issue's step 3. (An aggregate over such rows takes the `?? string.Empty` fallback instead — the silently-empty-sum mode of step 1.)

This strongly suggests the production repro's join executed with unmatched-fallback rows reaching projection (e.g. the right-hand dataset enumerating empty, or the join type mapping to an outer join upstream), which is consistent with every observation in #78 — `matchedCount: 16` (bare-name `Идентификатор` resolves on the base table even on unmerged rows), the empty sum, and both `KeyNotFoundException` stacks.

## Test results

`dotnet build -warnaserror`, `dotnet format --verify-no-changes` clean; `dotnet test`: 157 passed, 5 skipped (the reproductions), 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)