### PR TITLE
Resolve joined-table fields by entity and pad unmatched outer-join rows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,13 +30,14 @@ All translation work is done by internal classes:
 
 - **`TableFromQuery`** — derives the virtual `ITable` schema from the query's SELECT expressions
 - **`RowsFromDatasets`** — orchestrates the full query pipeline: locates the source table dataset by `schema.table` path, then applies each clause in order
-- **`JoinApplicator`** — materializes joined datasets into lists and applies join conditions (supports INNER, LEFT, RIGHT, FULL)
+- **`JoinApplicator`** — materializes joined datasets into lists and applies join conditions (supports INNER, LEFT, RIGHT, FULL). Tags the joined table's columns with their entity path (`QualifiedColumn`) so same-named columns from both sides stay distinct in merged rows, and pads unmatched outer-join rows with empty cells for the missing side
+- **`QualifiedColumn`** — an `IColumn` wrapper carrying the "schema.table" entity a joined column came from; deliberately a class (not a record) because the wrapped column types' `Equals`/`GetHashCode` throw by design
 - **`WhereExpressionBuilder`** — compiles a `BooleanReturning` *or* per-row `BooleanArrayReturning` AST node from `PureQL.CSharp.Model` into a `Func<IRow, bool>` LINQ predicate (entry point: `BuildPredicate(OneOf<BooleanReturning, BooleanArrayReturning>)`). Implements the per-row `each*` family — `EachEquality`, `EachComparison`, `EachAnd`/`EachOr`/`EachNot`, plus per-row arithmetic (`EachArithmetic`, `EachDateAddDays`/`EachDateDiffDays`, `EachTimeAddSeconds`/`EachTimeDiffSeconds`, `EachDateTimeAddSeconds`/`EachDateTimeDiffSeconds`)
 - **`OrderByApplicator`** — applies `IEnumerable<OrderByItem>` ordering, honouring per-item `SortDirection` (`Asc`/`Desc`)
 - **`GroupByApplicator`** — groups rows by the GROUP BY fields (or the whole set when only aggregates are selected), filters groups with HAVING, and emits one projected row per group (aggregate select expressions fold the group; field select expressions take the group key value)
 - **`AggregateEvaluator`** — evaluates single-value expressions over a group of rows: `Count`, `NumberAggregate` (sum/min/max/avg), `StringAggregate` (min/max, ordinal), `Date`/`DateTime`/`TimeAggregate` (min/max), plus HAVING boolean composites (equality/comparison/and/or/not over constants and aggregates)
 - **`DistinctApplicator`** — deduplicates the *projected* row set when `Query.Distinct == true` (SQL `SELECT DISTINCT` semantics)
-- **`CellValueExtractor`** — extracts typed .NET values from `ICell` for the seven supported column types: bool, date, datetime, double, string, time, uuid
+- **`CellValueExtractor`** — resolves a field reference (entity + field name) against a row and extracts typed .NET values from `ICell` for the seven supported column types: bool, date, datetime, double, string, time, uuid. Resolution prefers a `QualifiedColumn` matching the reference's entity, then the base table's (untagged) same-named column, then any same-named column
 - **`SelectColumns`** — the single source of truth for output columns: one per `SelectExpression`, named by the alias (falling back to the field name) and typed by the value type; used by both the schema and the row projection
 - **`ValueText`** — formats computed (aggregate) values as canonical invariant cell text that `CellValueExtractor` round-trips
 

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/CellValueExtractor.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/CellValueExtractor.cs
@@ -4,37 +4,57 @@ using Pure.RelationalSchema.Storage.Abstractions;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection;
 
+// Resolves a field reference against a row. A column tagged with the
+// reference's entity wins; otherwise the base table's (untagged) same-named
+// column; otherwise any same-named column. The fallbacks keep unqualified
+// rows (no joins, projected rows) and alias-style entities working.
 internal static class CellValueExtractor
 {
-    internal static ICell? GetCell(IRow row, string fieldName)
+    internal static ICell? GetCell(IRow row, string entity, string fieldName)
     {
+        ICell? unqualified = null;
+        ICell? sameName = null;
+
         foreach (KeyValuePair<IColumn, ICell> kvp in row.Cells)
         {
-            if (kvp.Key.Name.TextValue == fieldName)
+            if (kvp.Key.Name.TextValue != fieldName)
+            {
+                continue;
+            }
+
+            if (kvp.Key is not QualifiedColumn qualified)
+            {
+                unqualified ??= kvp.Value;
+            }
+            else if (qualified.Entity == entity)
             {
                 return kvp.Value;
             }
+            else
+            {
+                sameName ??= kvp.Value;
+            }
         }
 
-        return null;
+        return unqualified ?? sameName;
     }
 
-    internal static ICell GetRequiredCell(IRow row, string fieldName)
+    internal static ICell GetRequiredCell(IRow row, string entity, string fieldName)
     {
-        return GetCell(row, fieldName)
+        return GetCell(row, entity, fieldName)
             ?? throw new KeyNotFoundException(
                 $"Row has no column named '{fieldName}'."
             );
     }
 
-    internal static string? GetTextValue(IRow row, string fieldName)
+    internal static string? GetTextValue(IRow row, string entity, string fieldName)
     {
-        return GetCell(row, fieldName)?.Value.TextValue;
+        return GetCell(row, entity, fieldName)?.Value.TextValue;
     }
 
-    internal static double? GetDoubleValue(IRow row, string fieldName)
+    internal static double? GetDoubleValue(IRow row, string entity, string fieldName)
     {
-        string? text = GetTextValue(row, fieldName);
+        string? text = GetTextValue(row, entity, fieldName);
 
         return
             text is not null
@@ -48,23 +68,31 @@ internal static class CellValueExtractor
             : null;
     }
 
-    internal static bool? GetBoolValue(IRow row, string fieldName)
+    internal static bool? GetBoolValue(IRow row, string entity, string fieldName)
     {
-        string? text = GetTextValue(row, fieldName);
+        string? text = GetTextValue(row, entity, fieldName);
 
         return text is not null && bool.TryParse(text, out bool v) ? v : null;
     }
 
-    internal static DateOnly? GetDateOnlyValue(IRow row, string fieldName)
+    internal static DateOnly? GetDateOnlyValue(
+        IRow row,
+        string entity,
+        string fieldName
+    )
     {
-        string? text = GetTextValue(row, fieldName);
+        string? text = GetTextValue(row, entity, fieldName);
 
         return text is not null && DateOnly.TryParse(text, out DateOnly v) ? v : null;
     }
 
-    internal static DateTime? GetDateTimeValue(IRow row, string fieldName)
+    internal static DateTime? GetDateTimeValue(
+        IRow row,
+        string entity,
+        string fieldName
+    )
     {
-        string? text = GetTextValue(row, fieldName);
+        string? text = GetTextValue(row, entity, fieldName);
 
         return
             text is not null
@@ -78,16 +106,20 @@ internal static class CellValueExtractor
             : null;
     }
 
-    internal static TimeOnly? GetTimeOnlyValue(IRow row, string fieldName)
+    internal static TimeOnly? GetTimeOnlyValue(
+        IRow row,
+        string entity,
+        string fieldName
+    )
     {
-        string? text = GetTextValue(row, fieldName);
+        string? text = GetTextValue(row, entity, fieldName);
 
         return text is not null && TimeOnly.TryParse(text, out TimeOnly v) ? v : null;
     }
 
-    internal static Guid? GetGuidValue(IRow row, string fieldName)
+    internal static Guid? GetGuidValue(IRow row, string entity, string fieldName)
     {
-        string? text = GetTextValue(row, fieldName);
+        string? text = GetTextValue(row, entity, fieldName);
 
         return text is not null && Guid.TryParse(text, out Guid v) ? v : null;
     }

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/GroupByApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/GroupByApplicator.cs
@@ -80,11 +80,12 @@ internal static class GroupByApplicator
             );
         }
 
+        string fieldEntity = SelectColumns.FieldEntity(arrayReturning);
         string fieldName = SelectColumns.FieldName(arrayReturning);
 
         return new ProjectionItem(
             column,
-            rows => CellValueExtractor.GetRequiredCell(rows[0], fieldName)
+            rows => CellValueExtractor.GetRequiredCell(rows[0], fieldEntity, fieldName)
         );
     }
 
@@ -118,25 +119,33 @@ internal static class GroupByApplicator
             fields.Select(field =>
                 field.Match(
                     f =>
-                        CellValueExtractor.GetBoolValue(row, f.Field)?.ToString()
-                        ?? string.Empty,
+                        CellValueExtractor
+                            .GetBoolValue(row, f.Entity, f.Field)
+                            ?.ToString() ?? string.Empty,
                     f =>
-                        CellValueExtractor.GetDateOnlyValue(row, f.Field)?.ToString()
-                        ?? string.Empty,
+                        CellValueExtractor
+                            .GetDateOnlyValue(row, f.Entity, f.Field)
+                            ?.ToString() ?? string.Empty,
                     f =>
-                        CellValueExtractor.GetDateTimeValue(row, f.Field)?.ToString()
-                        ?? string.Empty,
+                        CellValueExtractor
+                            .GetDateTimeValue(row, f.Entity, f.Field)
+                            ?.ToString() ?? string.Empty,
                     _ => string.Empty,
                     f =>
-                        CellValueExtractor.GetDoubleValue(row, f.Field)?.ToString()
-                        ?? string.Empty,
+                        CellValueExtractor
+                            .GetDoubleValue(row, f.Entity, f.Field)
+                            ?.ToString() ?? string.Empty,
                     f =>
-                        CellValueExtractor.GetTimeOnlyValue(row, f.Field)?.ToString()
-                        ?? string.Empty,
+                        CellValueExtractor
+                            .GetTimeOnlyValue(row, f.Entity, f.Field)
+                            ?.ToString() ?? string.Empty,
                     f =>
-                        CellValueExtractor.GetGuidValue(row, f.Field)?.ToString()
-                        ?? string.Empty,
-                    f => CellValueExtractor.GetTextValue(row, f.Field) ?? string.Empty
+                        CellValueExtractor
+                            .GetGuidValue(row, f.Entity, f.Field)
+                            ?.ToString() ?? string.Empty,
+                    f =>
+                        CellValueExtractor.GetTextValue(row, f.Entity, f.Field)
+                        ?? string.Empty
                 )
             )
         );

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/JoinApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/JoinApplicator.cs
@@ -1,14 +1,24 @@
+using System.Runtime.CompilerServices;
 using Pure.RelationalSchema.Abstractions.Column;
-using Pure.RelationalSchema.HashCodes;
+using Pure.RelationalSchema.Abstractions.Table;
 using Pure.RelationalSchema.Storage.Abstractions;
 using PureQL.CSharp.Model;
+using String = Pure.Primitives.String.String;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection;
 
+// Applies one join: resolves the right-hand table by its "schema.table"
+// path, tags its columns with the join entity (QualifiedColumn) so
+// same-named columns from both sides stay distinct and addressable, merges
+// matched rows keeping every cell, and pads unmatched outer-join rows with
+// empty cells for the missing side so projection always sees every column.
 internal static class JoinApplicator
 {
-    internal static IQueryable<IRow> Apply(
+    private static readonly ICell EmptyCell = new Cell(new String(string.Empty));
+
+    internal static JoinedRows Apply(
         IQueryable<IRow> left,
+        IReadOnlyList<IColumn> leftColumns,
         List<IStoredSchemaDataSet> datasets,
         Join join
     )
@@ -21,30 +31,50 @@ internal static class JoinApplicator
         string tableName = reversedPath.First();
         string schemaName = reversedPath.Skip(1).First();
 
-        IEnumerable<IRow> right = datasets
+        KeyValuePair<ITable, IStoredTableDataSet> rightDataset = datasets
             .First(x => x.Schema.Name.TextValue == schemaName)
-            .First(x => x.Key.Name.TextValue == tableName)
-            .Value;
+            .First(x => x.Key.Name.TextValue == tableName);
+
+        List<IColumn> rightColumns =
+        [
+            .. rightDataset.Key.Columns.Select(column =>
+                (IColumn)new QualifiedColumn(join.Entity, column)
+            ),
+        ];
 
         Func<IRow, bool> onCondition = WhereExpressionBuilder
             .BuildPredicate(join.On)
             .Compile();
 
         List<IRow> leftList = [.. left];
-        List<IRow> rightList = [.. right];
+        List<IRow> rightList =
+        [
+            .. rightDataset
+                .Value.AsEnumerable()
+                .Select(row => Qualify(join.Entity, row)),
+        ];
 
         IEnumerable<IRow> result = join.Type switch
         {
             JoinType.Inner => InnerJoin(leftList, rightList, onCondition),
-            JoinType.Left => LeftJoin(leftList, rightList, onCondition),
-            JoinType.Right => RightJoin(leftList, rightList, onCondition),
-            JoinType.Full => FullJoin(leftList, rightList, onCondition),
+            JoinType.Left => LeftJoin(leftList, rightList, onCondition, rightColumns),
+            JoinType.Right => RightJoin(leftList, rightList, onCondition, leftColumns),
+            JoinType.Full => FullJoin(
+                leftList,
+                rightList,
+                onCondition,
+                leftColumns,
+                rightColumns
+            ),
             _ => throw new NotSupportedException(
                 $"JoinType {join.Type} is not supported."
             ),
         };
 
-        return result.AsQueryable();
+        return new JoinedRows(
+            result.AsQueryable(),
+            [.. leftColumns, .. rightColumns]
+        );
     }
 
     private static IEnumerable<IRow> InnerJoin(
@@ -60,7 +90,8 @@ internal static class JoinApplicator
     private static IEnumerable<IRow> LeftJoin(
         List<IRow> left,
         List<IRow> right,
-        Func<IRow, bool> onCondition
+        Func<IRow, bool> onCondition,
+        IReadOnlyList<IColumn> rightColumns
     )
     {
         return left.SelectMany(l =>
@@ -69,28 +100,31 @@ internal static class JoinApplicator
                 .Select(r => MergeRows(l, r))
                 .Where(onCondition)];
 
-            return matched.Count > 0 ? matched : [l];
+            return matched.Count > 0 ? matched : [Pad(l, rightColumns)];
         });
     }
 
     private static IEnumerable<IRow> RightJoin(
         List<IRow> left,
         List<IRow> right,
-        Func<IRow, bool> onCondition
+        Func<IRow, bool> onCondition,
+        IReadOnlyList<IColumn> leftColumns
     )
     {
         return right.SelectMany(r =>
         {
             List<IRow> matched = [.. left.Select(l => MergeRows(l, r)).Where(onCondition)];
 
-            return matched.Count > 0 ? matched : [r];
+            return matched.Count > 0 ? matched : [Pad(r, leftColumns)];
         });
     }
 
     private static IEnumerable<IRow> FullJoin(
         List<IRow> left,
         List<IRow> right,
-        Func<IRow, bool> onCondition
+        Func<IRow, bool> onCondition,
+        IReadOnlyList<IColumn> leftColumns,
+        IReadOnlyList<IColumn> rightColumns
     )
     {
         HashSet<int> matchedRightIndexes = [];
@@ -118,7 +152,7 @@ internal static class JoinApplicator
             }
             else
             {
-                result.Add(l);
+                result.Add(Pad(l, rightColumns));
             }
         }
 
@@ -126,45 +160,81 @@ internal static class JoinApplicator
         {
             if (!matchedRightIndexes.Contains(i))
             {
-                result.Add(right[i]);
+                result.Add(Pad(right[i], leftColumns));
             }
         }
 
         return result;
     }
 
+    private static IRow Qualify(string entity, IRow row)
+    {
+        Dictionary<IColumn, ICell> cells = new(ReferenceColumnComparer.Instance);
+
+        foreach (KeyValuePair<IColumn, ICell> cell in row.Cells)
+        {
+            cells[new QualifiedColumn(entity, cell.Key)] = cell.Value;
+        }
+
+        return new Row(cells);
+    }
+
     private static IRow MergeRows(IRow leftRow, IRow rightRow)
     {
-        HashSet<string> leftNames = [.. leftRow
-            .Cells.Keys.Select(c => c.Name.TextValue)];
+        Dictionary<IColumn, ICell> cells = new(ReferenceColumnComparer.Instance);
 
-        List<KeyValuePair<IColumn, ICell>> rightOnly = [.. rightRow
-            .Cells.Where(kvp => !leftNames.Contains(kvp.Key.Name.TextValue))];
+        foreach (KeyValuePair<IColumn, ICell> cell in leftRow.Cells)
+        {
+            cells[cell.Key] = cell.Value;
+        }
 
-        List<IColumn> allColumns =
-        [
-            .. leftRow
-                        .Cells.Keys,
-            .. rightOnly.Select(kvp => kvp.Key),
-        ];
+        foreach (KeyValuePair<IColumn, ICell> cell in rightRow.Cells)
+        {
+            cells[cell.Key] = cell.Value;
+        }
 
-        List<KeyValuePair<IColumn, ICell>> allCells =
-        [
-            .. leftRow
-                        .Cells,
-            .. rightOnly,
-        ];
+        return new Row(cells);
+    }
 
-        return new Row(
-            new Collections.Generic.Dictionary<IColumn, IColumn, ICell>(
-                allColumns,
-                c => c,
-                c =>
-                    allCells
-                        .First(kvp => kvp.Key.Name.TextValue == c.Name.TextValue)
-                        .Value,
-                c => new ColumnHash(c)
-            )
-        );
+    private static IRow Pad(IRow row, IReadOnlyList<IColumn> missingColumns)
+    {
+        Dictionary<IColumn, ICell> cells = new(ReferenceColumnComparer.Instance);
+
+        foreach (KeyValuePair<IColumn, ICell> cell in row.Cells)
+        {
+            cells[cell.Key] = cell.Value;
+        }
+
+        foreach (IColumn column in missingColumns)
+        {
+            cells[column] = EmptyCell;
+        }
+
+        return new Row(cells);
+    }
+
+    // Column instances are the identity of a cell within a row. The schema
+    // column types' own Equals/GetHashCode throw by design (hashing is meant
+    // to go through ColumnHash), so row dictionaries key by reference.
+    private sealed class ReferenceColumnComparer : IEqualityComparer<IColumn>
+    {
+        public static readonly ReferenceColumnComparer Instance = new();
+
+        public bool Equals(IColumn? x, IColumn? y)
+        {
+            return ReferenceEquals(x, y);
+        }
+
+        public int GetHashCode(IColumn obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
     }
 }
+
+// One applied join: the joined row set plus the columns every emitted row
+// carries (left side's columns followed by the qualified right columns).
+internal sealed record JoinedRows(
+    IQueryable<IRow> Rows,
+    IReadOnlyList<IColumn> Columns
+);

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/OrderByApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/OrderByApplicator.cs
@@ -33,26 +33,26 @@ internal static class OrderByApplicator
             f =>
                 descending
                     ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetBoolValue(row, f.Field)
+                        CellValueExtractor.GetBoolValue(row, f.Entity, f.Field)
                     )
                     : source.OrderBy(row =>
-                        CellValueExtractor.GetBoolValue(row, f.Field)
+                        CellValueExtractor.GetBoolValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetDateOnlyValue(row, f.Field)
+                        CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field)
                     )
                     : source.OrderBy(row =>
-                        CellValueExtractor.GetDateOnlyValue(row, f.Field)
+                        CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetDateTimeValue(row, f.Field)
+                        CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field)
                     )
                     : source.OrderBy(row =>
-                        CellValueExtractor.GetDateTimeValue(row, f.Field)
+                        CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field)
                     ),
             _ =>
                 descending
@@ -61,34 +61,34 @@ internal static class OrderByApplicator
             f =>
                 descending
                     ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetDoubleValue(row, f.Field)
+                        CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field)
                     )
                     : source.OrderBy(row =>
-                        CellValueExtractor.GetDoubleValue(row, f.Field)
+                        CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetTimeOnlyValue(row, f.Field)
+                        CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field)
                     )
                     : source.OrderBy(row =>
-                        CellValueExtractor.GetTimeOnlyValue(row, f.Field)
+                        CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetGuidValue(row, f.Field)
+                        CellValueExtractor.GetGuidValue(row, f.Entity, f.Field)
                     )
                     : source.OrderBy(row =>
-                        CellValueExtractor.GetGuidValue(row, f.Field)
+                        CellValueExtractor.GetGuidValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetTextValue(row, f.Field)
+                        CellValueExtractor.GetTextValue(row, f.Entity, f.Field)
                     )
                     : source.OrderBy(row =>
-                        CellValueExtractor.GetTextValue(row, f.Field)
+                        CellValueExtractor.GetTextValue(row, f.Entity, f.Field)
                     )
         );
     }
@@ -104,26 +104,26 @@ internal static class OrderByApplicator
             f =>
                 descending
                     ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetBoolValue(row, f.Field)
+                        CellValueExtractor.GetBoolValue(row, f.Entity, f.Field)
                     )
                     : source.ThenBy(row =>
-                        CellValueExtractor.GetBoolValue(row, f.Field)
+                        CellValueExtractor.GetBoolValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetDateOnlyValue(row, f.Field)
+                        CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field)
                     )
                     : source.ThenBy(row =>
-                        CellValueExtractor.GetDateOnlyValue(row, f.Field)
+                        CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetDateTimeValue(row, f.Field)
+                        CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field)
                     )
                     : source.ThenBy(row =>
-                        CellValueExtractor.GetDateTimeValue(row, f.Field)
+                        CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field)
                     ),
             _ =>
                 descending
@@ -132,34 +132,34 @@ internal static class OrderByApplicator
             f =>
                 descending
                     ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetDoubleValue(row, f.Field)
+                        CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field)
                     )
                     : source.ThenBy(row =>
-                        CellValueExtractor.GetDoubleValue(row, f.Field)
+                        CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetTimeOnlyValue(row, f.Field)
+                        CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field)
                     )
                     : source.ThenBy(row =>
-                        CellValueExtractor.GetTimeOnlyValue(row, f.Field)
+                        CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetGuidValue(row, f.Field)
+                        CellValueExtractor.GetGuidValue(row, f.Entity, f.Field)
                     )
                     : source.ThenBy(row =>
-                        CellValueExtractor.GetGuidValue(row, f.Field)
+                        CellValueExtractor.GetGuidValue(row, f.Entity, f.Field)
                     ),
             f =>
                 descending
                     ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetTextValue(row, f.Field)
+                        CellValueExtractor.GetTextValue(row, f.Entity, f.Field)
                     )
                     : source.ThenBy(row =>
-                        CellValueExtractor.GetTextValue(row, f.Field)
+                        CellValueExtractor.GetTextValue(row, f.Entity, f.Field)
                     )
         );
     }

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/QualifiedColumn.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/QualifiedColumn.cs
@@ -1,0 +1,22 @@
+using Pure.Primitives.Abstractions.String;
+using Pure.RelationalSchema.Abstractions.Column;
+using Pure.RelationalSchema.Abstractions.ColumnType;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection;
+
+// A joined table's column carried through the pipeline, tagged with the
+// "schema.table" entity it came from. Same-named columns from different
+// tables stay distinct in a merged row, and CellValueExtractor resolves an
+// entity-qualified field reference to the column of the matching entity.
+// A class (not a record) on purpose: the wrapped column's Equals/GetHashCode
+// throw by design, so identity semantics must not delegate to it.
+internal sealed class QualifiedColumn(string entity, IColumn origin) : IColumn
+{
+    private readonly IColumn _origin = origin;
+
+    public string Entity { get; } = entity;
+
+    public IString Name => _origin.Name;
+
+    public IColumnType Type => _origin.Type;
+}

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
@@ -58,9 +58,22 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
 
         if (query.Join is not null)
         {
+            IReadOnlyList<IColumn> columns =
+            [
+                .. targetTableDataset.TableSchema.Columns,
+            ];
+
             foreach (Join join in query.Join)
             {
-                queryable = JoinApplicator.Apply(queryable, datasetList, join);
+                JoinedRows joined = JoinApplicator.Apply(
+                    queryable,
+                    columns,
+                    datasetList,
+                    join
+                );
+
+                queryable = joined.Rows;
+                columns = joined.Columns;
             }
         }
 
@@ -119,7 +132,11 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
                     new Collections.Generic.Dictionary<ProjectionItem, IColumn, ICell>(
                         plan,
                         item => item.Column,
-                        item => CellValueExtractor.GetRequiredCell(row, item.FieldName),
+                        item => CellValueExtractor.GetRequiredCell(
+                            row,
+                            item.FieldEntity,
+                            item.FieldName
+                        ),
                         column => new ColumnHash(column)
                     )
                 )
@@ -135,9 +152,14 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
             )
             : new ProjectionItem(
                 SelectColumns.OutputColumn(expression),
+                SelectColumns.FieldEntity(array),
                 SelectColumns.FieldName(array)
             );
     }
 
-    private sealed record ProjectionItem(IColumn Column, string FieldName);
+    private sealed record ProjectionItem(
+        IColumn Column,
+        string FieldEntity,
+        string FieldName
+    );
 }

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/SelectColumns.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/SelectColumns.cs
@@ -62,6 +62,19 @@ internal sealed record SelectColumns : IEnumerable<IColumn>
         );
     }
 
+    internal static string FieldEntity(ArrayReturning returning)
+    {
+        return returning.Match(
+            b => b.AsT1.Entity,
+            d => d.AsT1.Entity,
+            dt => dt.AsT1.Entity,
+            n => n.AsT1.Entity,
+            s => s.AsT1.Entity,
+            t => t.AsT1.Entity,
+            u => u.AsT1.Entity
+        );
+    }
+
     private static IColumnType SingleValueType(SingleValueReturning returning)
     {
         return returning.Match<IColumnType>(

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/WhereExpressionBuilder.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/WhereExpressionBuilder.cs
@@ -159,6 +159,21 @@ internal static class WhereExpressionBuilder
         return Expression.Lambda<Func<IRow, T>>(typedBody, rowParam).Compile();
     }
 
+    private static Expression FieldValue(
+        MethodInfo getCellValueMethod,
+        ParameterExpression row,
+        string entity,
+        string field
+    )
+    {
+        return Expression.Call(
+            getCellValueMethod,
+            row,
+            Expression.Constant(entity),
+            Expression.Constant(field)
+        );
+    }
+
     private static Expression BuildBoolean(
         BooleanReturning returning,
         ParameterExpression row
@@ -237,11 +252,13 @@ internal static class WhereExpressionBuilder
             eq =>
                 BuildContainmentEquality(
                     left: eq.Left.IsT1,
+                    leftEntity: eq.Left.IsT1 ? eq.Left.AsT1.Entity : null,
                     leftField: eq.Left.IsT1 ? eq.Left.AsT1.Field : null,
                     leftScalar: eq.Left.IsT2
                         ? (IEnumerable<DateOnly>?)eq.Left.AsT2.Value
                         : null,
                     right: eq.Right.IsT1,
+                    rightEntity: eq.Right.IsT1 ? eq.Right.AsT1.Entity : null,
                     rightField: eq.Right.IsT1 ? eq.Right.AsT1.Field : null,
                     rightScalar: eq.Right.IsT2
                         ? (IEnumerable<DateOnly>?)eq.Right.AsT2.Value
@@ -252,11 +269,13 @@ internal static class WhereExpressionBuilder
             eq =>
                 BuildContainmentEquality(
                     left: eq.Left.IsT1,
+                    leftEntity: eq.Left.IsT1 ? eq.Left.AsT1.Entity : null,
                     leftField: eq.Left.IsT1 ? eq.Left.AsT1.Field : null,
                     leftScalar: eq.Left.IsT2
                         ? (IEnumerable<DateTime>?)eq.Left.AsT2.Value
                         : null,
                     right: eq.Right.IsT1,
+                    rightEntity: eq.Right.IsT1 ? eq.Right.AsT1.Entity : null,
                     rightField: eq.Right.IsT1 ? eq.Right.AsT1.Field : null,
                     rightScalar: eq.Right.IsT2
                         ? (IEnumerable<DateTime>?)eq.Right.AsT2.Value
@@ -267,11 +286,13 @@ internal static class WhereExpressionBuilder
             eq =>
                 BuildContainmentEquality(
                     left: eq.Left.IsT1,
+                    leftEntity: eq.Left.IsT1 ? eq.Left.AsT1.Entity : null,
                     leftField: eq.Left.IsT1 ? eq.Left.AsT1.Field : null,
                     leftScalar: eq.Left.IsT2
                         ? (IEnumerable<double>?)eq.Left.AsT2.Value
                         : null,
                     right: eq.Right.IsT1,
+                    rightEntity: eq.Right.IsT1 ? eq.Right.AsT1.Entity : null,
                     rightField: eq.Right.IsT1 ? eq.Right.AsT1.Field : null,
                     rightScalar: eq.Right.IsT2
                         ? (IEnumerable<double>?)eq.Right.AsT2.Value
@@ -283,11 +304,13 @@ internal static class WhereExpressionBuilder
             eq =>
                 BuildContainmentEquality(
                     left: eq.Left.IsT1,
+                    leftEntity: eq.Left.IsT1 ? eq.Left.AsT1.Entity : null,
                     leftField: eq.Left.IsT1 ? eq.Left.AsT1.Field : null,
                     leftScalar: eq.Left.IsT2
                         ? (IEnumerable<TimeOnly>?)eq.Left.AsT2.Value
                         : null,
                     right: eq.Right.IsT1,
+                    rightEntity: eq.Right.IsT1 ? eq.Right.AsT1.Entity : null,
                     rightField: eq.Right.IsT1 ? eq.Right.AsT1.Field : null,
                     rightScalar: eq.Right.IsT2
                         ? (IEnumerable<TimeOnly>?)eq.Right.AsT2.Value
@@ -298,11 +321,13 @@ internal static class WhereExpressionBuilder
             eq =>
                 BuildContainmentEquality(
                     left: eq.Left.IsT1,
+                    leftEntity: eq.Left.IsT1 ? eq.Left.AsT1.Entity : null,
                     leftField: eq.Left.IsT1 ? eq.Left.AsT1.Field : null,
                     leftScalar: eq.Left.IsT2
                         ? (IEnumerable<Guid>?)eq.Left.AsT2.Value
                         : null,
                     right: eq.Right.IsT1,
+                    rightEntity: eq.Right.IsT1 ? eq.Right.AsT1.Entity : null,
                     rightField: eq.Right.IsT1 ? eq.Right.AsT1.Field : null,
                     rightScalar: eq.Right.IsT2
                         ? (IEnumerable<Guid>?)eq.Right.AsT2.Value
@@ -320,9 +345,11 @@ internal static class WhereExpressionBuilder
     {
         return BuildContainmentEquality(
             left: eq.Left.IsT1,
+            leftEntity: eq.Left.IsT1 ? eq.Left.AsT1.Entity : null,
             leftField: eq.Left.IsT1 ? eq.Left.AsT1.Field : null,
             leftScalar: eq.Left.IsT0 ? (IEnumerable<bool>?)eq.Left.AsT0.Value : null,
             right: eq.Right.IsT1,
+            rightEntity: eq.Right.IsT1 ? eq.Right.AsT1.Entity : null,
             rightField: eq.Right.IsT1 ? eq.Right.AsT1.Field : null,
             rightScalar: eq.Right.IsT0 ? (IEnumerable<bool>?)eq.Right.AsT0.Value : null,
             row,
@@ -337,9 +364,11 @@ internal static class WhereExpressionBuilder
     {
         return BuildContainmentEquality(
             left: eq.Left.IsT1,
+            leftEntity: eq.Left.IsT1 ? eq.Left.AsT1.Entity : null,
             leftField: eq.Left.IsT1 ? eq.Left.AsT1.Field : null,
             leftScalar: eq.Left.IsT2 ? (IEnumerable<string>?)eq.Left.AsT2.Value : null,
             right: eq.Right.IsT1,
+            rightEntity: eq.Right.IsT1 ? eq.Right.AsT1.Entity : null,
             rightField: eq.Right.IsT1 ? eq.Right.AsT1.Field : null,
             rightScalar: eq.Right.IsT2 ? (IEnumerable<string>?)eq.Right.AsT2.Value : null,
             row,
@@ -349,9 +378,11 @@ internal static class WhereExpressionBuilder
 
     private static Expression BuildContainmentEquality<T>(
         bool left,
+        string? leftEntity,
         string? leftField,
         IEnumerable<T>? leftScalar,
         bool right,
+        string? rightEntity,
         string? rightField,
         IEnumerable<T>? rightScalar,
         ParameterExpression row,
@@ -367,10 +398,11 @@ internal static class WhereExpressionBuilder
 
         if (left && rightScalar is not null)
         {
-            Expression fieldExpr = Expression.Call(
+            Expression fieldExpr = FieldValue(
                 getCellValueMethod,
                 row,
-                Expression.Constant(leftField)
+                leftEntity!,
+                leftField!
             );
             Expression scalarExpr = Expression.Constant(
                 rightScalar.ToArray(),
@@ -381,10 +413,11 @@ internal static class WhereExpressionBuilder
 
         if (right && leftScalar is not null)
         {
-            Expression fieldExpr = Expression.Call(
+            Expression fieldExpr = FieldValue(
                 getCellValueMethod,
                 row,
-                Expression.Constant(rightField)
+                rightEntity!,
+                rightField!
             );
             Expression scalarExpr = Expression.Constant(
                 leftScalar.ToArray(),
@@ -395,15 +428,17 @@ internal static class WhereExpressionBuilder
 
         if (left && right)
         {
-            Expression left1 = Expression.Call(
+            Expression left1 = FieldValue(
                 getCellValueMethod,
                 row,
-                Expression.Constant(leftField)
+                leftEntity!,
+                leftField!
             );
-            Expression right1 = Expression.Call(
+            Expression right1 = FieldValue(
                 getCellValueMethod,
                 row,
-                Expression.Constant(rightField)
+                rightEntity!,
+                rightField!
             );
             return Expression.Equal(left1, right1);
         }
@@ -467,11 +502,7 @@ internal static class WhereExpressionBuilder
             scalar => Expression.Constant(scalar.Value.All(v => v)),
             field =>
                 Expression.Equal(
-                    Expression.Call(
-                        GetBoolValueMethod,
-                        row,
-                        Expression.Constant(field.Field)
-                    ),
+                    FieldValue(GetBoolValueMethod, row, field.Entity, field.Field),
                     Expression.Constant((bool?)true, typeof(bool?))
                 ),
             _ => throw new NotSupportedException(ParameterNotSupported),
@@ -668,17 +699,13 @@ internal static class WhereExpressionBuilder
         ParameterExpression row
     )
     {
-        return returning.Match<Expression>(
+        return returning.Match(
             scalar => Expression.Constant(
                 (bool?)scalar.Value.FirstOrDefault(),
                 typeof(bool?)
             ),
             field =>
-                Expression.Call(
-                    GetBoolValueMethod,
-                    row,
-                    Expression.Constant(field.Field)
-                ),
+                FieldValue(GetBoolValueMethod, row, field.Entity, field.Field),
             _ => throw new NotSupportedException(ParameterNotSupported),
             _ => throw new NotSupportedException(
                 "Nested each-comparison as a boolean value is not supported."
@@ -706,11 +733,7 @@ internal static class WhereExpressionBuilder
         return returning.Match(
             _ => throw new NotSupportedException(ParameterNotSupported),
             field =>
-                Expression.Call(
-                    GetDoubleValueMethod,
-                    row,
-                    Expression.Constant(field.Field)
-                ),
+                FieldValue(GetDoubleValueMethod, row, field.Entity, field.Field),
             scalar => Expression.Constant(
                 (double?)scalar.Value.FirstOrDefault(),
                 typeof(double?)
@@ -727,14 +750,10 @@ internal static class WhereExpressionBuilder
         ParameterExpression row
     )
     {
-        return returning.Match<Expression>(
+        return returning.Match(
             _ => throw new NotSupportedException(ParameterNotSupported),
             field =>
-                Expression.Call(
-                    GetTextValueMethod,
-                    row,
-                    Expression.Constant(field.Field)
-                ),
+                FieldValue(GetTextValueMethod, row, field.Entity, field.Field),
             scalar => Expression.Constant(
                 scalar.Value.FirstOrDefault(),
                 typeof(string)
@@ -750,11 +769,7 @@ internal static class WhereExpressionBuilder
         return returning.Match(
             _ => throw new NotSupportedException(ParameterNotSupported),
             field =>
-                Expression.Call(
-                    GetDateOnlyValueMethod,
-                    row,
-                    Expression.Constant(field.Field)
-                ),
+                FieldValue(GetDateOnlyValueMethod, row, field.Entity, field.Field),
             scalar => Expression.Constant(
                 (DateOnly?)scalar.Value.FirstOrDefault(),
                 typeof(DateOnly?)
@@ -771,11 +786,7 @@ internal static class WhereExpressionBuilder
         return returning.Match(
             _ => throw new NotSupportedException(ParameterNotSupported),
             field =>
-                Expression.Call(
-                    GetTimeOnlyValueMethod,
-                    row,
-                    Expression.Constant(field.Field)
-                ),
+                FieldValue(GetTimeOnlyValueMethod, row, field.Entity, field.Field),
             scalar => Expression.Constant(
                 (TimeOnly?)scalar.Value.FirstOrDefault(),
                 typeof(TimeOnly?)
@@ -792,11 +803,7 @@ internal static class WhereExpressionBuilder
         return returning.Match(
             _ => throw new NotSupportedException(ParameterNotSupported),
             field =>
-                Expression.Call(
-                    GetDateTimeValueMethod,
-                    row,
-                    Expression.Constant(field.Field)
-                ),
+                FieldValue(GetDateTimeValueMethod, row, field.Entity, field.Field),
             scalar => Expression.Constant(
                 (DateTime?)scalar.Value.FirstOrDefault(),
                 typeof(DateTime?)
@@ -810,14 +817,10 @@ internal static class WhereExpressionBuilder
         ParameterExpression row
     )
     {
-        return returning.Match<Expression>(
+        return returning.Match(
             _ => throw new NotSupportedException(ParameterNotSupported),
             field =>
-                Expression.Call(
-                    GetGuidValueMethod,
-                    row,
-                    Expression.Constant(field.Field)
-                ),
+                FieldValue(GetGuidValueMethod, row, field.Entity, field.Field),
             scalar => Expression.Constant(
                 (Guid?)scalar.Value.FirstOrDefault(),
                 typeof(Guid?)

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/CollidingNameDatabase.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/CollidingNameDatabase.cs
@@ -11,7 +11,7 @@ namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
 // A multi-schema dataset where every table carries a same-named primary-key
 // column ("id") — the shape of any real schema that uses a conventional PK
 // name. This deliberately violates SampleDatabase's globally-unique-name
-// invariant to reproduce the joined-column resolution bugs of issues #77 and
+// invariant to cover the joined-column resolution bugs of issues #77 and
 // #78: planner.needs joins to refs.specialties (needs.spec_id -> specialties.id)
 // and to billing.estimates (needs.id -> estimates.need_id, 1:1).
 internal sealed class CollidingNameDatabase

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/SampleDatabase.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/SampleDatabase.cs
@@ -16,9 +16,9 @@ namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
 //   - Ground-truth record lists (UserRows, OrderRows, ...) so tests compute
 //     expected results independently.
 //
-// Every column name is globally unique because the translator resolves fields
-// by bare column name across merged (joined) rows; unique names keep joins and
-// projections unambiguous. Column types match the field kind used to select
+// Every column name is globally unique so tests stay unambiguous regardless
+// of entity qualification (CollidingNameDatabase covers same-named columns
+// across joined tables). Column types match the field kind used to select
 // them (uuid/string/double/bool/date/datetime/time).
 internal sealed class SampleDatabase
 {

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinColumnNameCollisionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinColumnNameCollisionTests.cs
@@ -8,16 +8,13 @@ using PureQL.CSharp.Model.Returnings;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
 
-#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
-
-// Reproduces issue #77: when the from table and a joined table both carry a
-// column with the same name (here the conventional PK name "id"), any
-// reference to that name on the joined side — in select, groupBy, or the
-// join's own on clause — must resolve to the joined table's value, not be
-// silently shadowed by the base table's same-named column.
+// Regression tests for issue #77: when the from table and a joined table
+// both carry a column with the same name (here the conventional PK name
+// "id"), any reference to that name on the joined side — in select, groupBy,
+// or the join's own on clause — must resolve to the joined table's value,
+// not be silently shadowed by the base table's same-named column.
 [Trait("Clause", "Join")]
 [Trait("Feature", "ColumnNameCollision")]
-[Trait("Status", "KnownGap")]
 public sealed class JoinColumnNameCollisionTests
 {
     private static Join NeedsToSpecialtiesJoin()
@@ -46,10 +43,7 @@ public sealed class JoinColumnNameCollisionTests
         );
     }
 
-    [Fact(
-        Skip = "Issue #77: the join's on clause resolves the joined table's "
-            + "same-named column to the base table's value."
-    )]
+    [Fact]
     public void JoinOnClauseWithSameNamedColumnMatchesJoinedTableValues()
     {
         CollidingNameDatabase db = new CollidingNameDatabase();
@@ -85,10 +79,7 @@ public sealed class JoinColumnNameCollisionTests
         Assert.Equal(expected, result.Count);
     }
 
-    [Fact(
-        Skip = "Issue #77: selecting the joined table's same-named column "
-            + "returns the base table's value instead."
-    )]
+    [Fact]
     public void SelectOfSameNamedColumnFromJoinedTableReturnsItsValues()
     {
         CollidingNameDatabase db = new CollidingNameDatabase();
@@ -132,10 +123,7 @@ public sealed class JoinColumnNameCollisionTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(
-        Skip = "Issue #77: grouping by the joined table's same-named column "
-            + "groups by the base table's value instead."
-    )]
+    [Fact]
     public void GroupByOfSameNamedColumnFromJoinedTableGroupsByItsValues()
     {
         CollidingNameDatabase db = new CollidingNameDatabase();

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinedTableColumnProjectionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinedTableColumnProjectionTests.cs
@@ -8,20 +8,19 @@ using PureQL.CSharp.Model.Returnings;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
 
-#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
-
-// Reproduces issue #78: a select item that references a joined-table column
-// whose name does NOT collide with any base-table column must still see that
-// column after the join — plainly projected, aggregated over the whole set,
-// or used as a groupBy key. The joining tables share the PK name "id" (the
-// shape of the reported schema), but the referenced columns themselves
-// ("actual_hours", "estimate_status") are unique to the joined table.
+// Regression tests for issue #78: a select item that references a
+// joined-table column whose name does NOT collide with any base-table column
+// must still see that column after the join — plainly projected, aggregated
+// over the whole set, or used as a groupBy key. The joining tables share the
+// PK name "id" (the shape of the reported schema), but the referenced
+// columns themselves ("actual_hours", "estimate_status") are unique to the
+// joined table.
 //
 // The inner-join tests transcribe the issue's repro steps directly. The
-// left-join tests pin the one in-library path that produces the reported
-// symptoms (KeyNotFoundException from projection / silently empty
-// aggregates): unmatched outer-join rows pass through unmerged, without the
-// joined table's columns, instead of carrying null cells for them.
+// left-join tests pin the path that produced the reported symptoms
+// (KeyNotFoundException from projection / silently empty aggregates):
+// unmatched outer-join rows must carry the joined table's columns as empty
+// (null-semantics) cells rather than passing through without them.
 [Trait("Clause", "Join")]
 [Trait("Feature", "JoinedColumnProjection")]
 public sealed class JoinedTableColumnProjectionTests
@@ -209,12 +208,7 @@ public sealed class JoinedTableColumnProjectionTests
         Assert.Equal(expected, actual);
     }
 
-    [Fact(
-        Skip = "Issue #78: unmatched outer-join rows lack the joined table's "
-            + "columns entirely, so projecting one throws KeyNotFoundException "
-            + "instead of yielding null cells."
-    )]
-    [Trait("Status", "KnownGap")]
+    [Fact]
     public void LeftJoinUnmatchedRowsExposeJoinedColumnsAsNullCells()
     {
         CollidingNameDatabase db = new CollidingNameDatabase();
@@ -277,12 +271,7 @@ public sealed class JoinedTableColumnProjectionTests
         Assert.Equal(unmatched, cells.Count(hours => hours is null));
     }
 
-    [Fact(
-        Skip = "Issue #78: grouping by a joined column crashes with "
-            + "KeyNotFoundException when a group's rows come from the "
-            + "unmatched outer-join fallback."
-    )]
-    [Trait("Status", "KnownGap")]
+    [Fact]
     public void LeftJoinGroupByJoinedColumnPutsUnmatchedRowsInNullGroup()
     {
         CollidingNameDatabase db = new CollidingNameDatabase();


### PR DESCRIPTION
## Summary

Fixes #77 and Fixes #78 — the joined-column resolution bugs reproduced by the tests merged in #79. All five formerly-skipped reproduction tests are now enabled and pass, alongside the rest of the suite (162/162).

## Root causes

- **#77**: field references resolved by bare column name (`field.Entity` discarded end-to-end), and `JoinApplicator.MergeRows` dropped same-named right-hand columns outright. Any reference to a joined table's column whose name collided with a base-table column resolved to the base table's value — in `select`, `groupBy`, and the join's own `on` clause.
- **#78**: unmatched LEFT/RIGHT/FULL join rows passed through unmerged, without the other side's columns, so projecting or grouping by a joined column crashed with `KeyNotFoundException` and aggregates over it silently returned empty.

## Changes

- **`QualifiedColumn`** (new): an `IColumn` wrapper tagging a joined table's columns with the `"schema.table"` entity they came from. Merged rows now keep every cell from both sides — same-named columns stay distinct and addressable. It is a class rather than a record, and join-row dictionaries key by reference, because the schema column types' `Equals`/`GetHashCode` throw by design (hashing is meant to go through `ColumnHash`).
- **`CellValueExtractor`** resolves `(entity, field)` references with three tiers: a `QualifiedColumn` matching the reference's entity wins; then the base table's untagged same-named column; then any same-named column. The fallbacks keep unqualified rows (no joins, projected rows) and alias-style entities behaving exactly as before.
- **`WhereExpressionBuilder`**, **`GroupByApplicator`**, **`OrderByApplicator`**, **`RowsFromDatasets`**, and **`SelectColumns`** thread the field's entity into resolution everywhere a bare name was used before.
- **`JoinApplicator`** pads unmatched outer-join rows with empty (null-semantics) cells for the missing side's columns — column metadata is threaded through consecutive joins via the new `JoinedRows` result, so padding works even when a side has zero rows. Unmatched rows now form a null group under `groupBy` instead of crashing.

## Behaviour notes

- SQL semantics for outer joins: a missing side contributes null cells (empty text, which every typed getter already parses as null), not missing columns.
- No public API changes — everything touched is `internal`. `dotnet pack` with package validation against the `0.1.0-preview.2.1.1` baseline passes.

## Verification

- `dotnet build -warnaserror` (net8.0/net9.0/net10.0): clean
- `dotnet format --verify-no-changes`: clean
- `dotnet test`: **162 passed, 0 skipped, 0 failed** — including the five reproduction tests from #79, un-skipped here as regression coverage (`JoinColumnNameCollisionTests`, the two left-join tests in `JoinedTableColumnProjectionTests`)
- Release pack with package validation: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)