### PR TITLE
Expand join, filtration, aggregate and group-by test coverage

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/AggregateOverPerRowArithmeticTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/AggregateOverPerRowArithmeticTests.cs
@@ -1,0 +1,170 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachArithmetics;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Aggregates;
+
+// An aggregate's argument may be any array-returning expression, including
+// per-row arithmetic over fields of both joined tables: sum(qty * price)
+// folds the computed per-row products, not a stored column.
+[Trait("Clause", "Select")]
+[Trait("Feature", "AggregateOverArithmetic")]
+public sealed class AggregateOverPerRowArithmeticTests
+{
+    private static Join ItemsToProductsJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Products.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.ProductId
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Products.Entity,
+                                SampleDatabase.Products.Id
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static SelectExpression SumOfQuantityTimesPrice(string alias)
+    {
+        return new SelectExpression(
+            new SingleValueReturning(
+                new NumberReturning(
+                    new NumberAggregate(
+                        new SumNumber(
+                            new NumberArrayReturning(
+                                new EachArithmetic(
+                                    new EachMultiply(
+                                        [
+                                            new NumberArrayReturning(
+                                                new NumberField(
+                                                    SampleDatabase.OrderItems.Entity,
+                                                    SampleDatabase.OrderItems.Qty
+                                                )
+                                            ),
+                                            new NumberArrayReturning(
+                                                new NumberField(
+                                                    SampleDatabase.Products.Entity,
+                                                    SampleDatabase.Products.Price
+                                                )
+                                            ),
+                                        ]
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            alias
+        );
+    }
+
+    private static double PriceOf(SampleDatabase db, Guid productId)
+    {
+        return db.ProductRows
+            .Single(product => product.ProductId == productId)
+            .ProductPrice;
+    }
+
+    [Fact]
+    public void SumOfQuantityTimesPriceGroupedByOrderComputesRevenue()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.OrderItems.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.OrderId
+                            )
+                        )
+                    )
+                ),
+                SumOfQuantityTimesPrice("revenue"),
+            ],
+            where: null,
+            [ItemsToProductsJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.OrderItems.Entity,
+                        SampleDatabase.OrderItems.OrderId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = db.OrderItemRows
+            .GroupBy(item => item.ItemOrderId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Sum(item =>
+                    item.ItemQty * PriceOf(db, item.ItemProductId)
+                )
+            );
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.OrderItems.OrderId)!.Value,
+            row => row.Double("revenue")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void WholeSetSumOfQuantityTimesPriceComputesTotalRevenue()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.OrderItems.Entity),
+            [SumOfQuantityTimesPrice("revenue")],
+            where: null,
+            [ItemsToProductsJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double expected = db.OrderItemRows.Sum(item =>
+            item.ItemQty * PriceOf(db, item.ItemProductId)
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expected, result.Row(0).Double("revenue"));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/CrossSchemaJoinAggregateTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/CrossSchemaJoinAggregateTests.cs
@@ -1,0 +1,139 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.DateTime;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Aggregates;
+
+// Aggregates folding a column of a table joined in from another schema:
+// per-user login statistics from audit.logins joined onto shop.users, with
+// a temporal max and a count over the joined side.
+[Trait("Clause", "Select")]
+[Trait("Feature", "CrossSchemaAggregate")]
+public sealed class CrossSchemaJoinAggregateTests
+{
+    private static Join UsersToLoginsJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Logins.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Logins.Entity,
+                                SampleDatabase.Logins.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void PerUserMaxAndCountOverCrossSchemaLoginsFoldTheJoinedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new DateTimeReturning(
+                            new DateTimeAggregate(
+                                new MaxDateTime(
+                                    new DateTimeArrayReturning(
+                                        new DateTimeField(
+                                            SampleDatabase.Logins.Entity,
+                                            SampleDatabase.Logins.At
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "lastLoginAt"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Logins.Entity,
+                                            SampleDatabase.Logins.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "loginCount"
+                ),
+            ],
+            where: null,
+            [UsersToLoginsJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Users.Entity,
+                        SampleDatabase.Users.Id
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, (DateTime, double)> expected = db.LoginRows
+            .GroupBy(login => login.LoginUserId)
+            .ToDictionary(
+                group => group.Key,
+                group =>
+                    (
+                        group.Max(login => login.LoginAt),
+                        (double)group.Count()
+                    )
+            );
+
+        Dictionary<Guid, (DateTime, double)> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Users.Id)!.Value,
+            row =>
+                (
+                    row.DateTime("lastLoginAt")!.Value,
+                    row.Double("loginCount")!.Value
+                )
+        );
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Api/DuplicateSchemaNameTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Api/DuplicateSchemaNameTests.cs
@@ -1,0 +1,165 @@
+using Pure.RelationalSchema.Abstractions.Column;
+using Pure.RelationalSchema.Abstractions.Schema;
+using Pure.RelationalSchema.Abstractions.Table;
+using Pure.RelationalSchema.ColumnType;
+using Pure.RelationalSchema.HashCodes;
+using Pure.RelationalSchema.Storage.Abstractions;
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+using String = Pure.Primitives.String.String;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Api;
+
+#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
+
+// PureQLProjection accepts an open IEnumerable<IStoredSchemaDataSet>, and
+// nothing forbids two datasets from sharing a schema name (a host that
+// concatenates datasets from several sources produces exactly this shape).
+// Entity resolution must find a "schema.table" pair wherever it lives, but
+// today only the first dataset with a matching schema name is consulted
+// (issue #84).
+[Trait("Clause", "From")]
+[Trait("Feature", "EntityResolution")]
+public sealed class DuplicateSchemaNameTests
+{
+    private const string SchemaName = "dup";
+    private const string AlphaValue = "alpha-value";
+    private const string BetaValue = "beta-value";
+
+    private static IStoredSchemaDataSet SingleTableDataset(
+        string tableName,
+        string columnName,
+        string cellText
+    )
+    {
+        IColumn column = new Column.Column(
+            new String(columnName),
+            new StringColumnType()
+        );
+
+        ITable table = new Table.Table(new String(tableName), [column], []);
+
+        IRow row = new Row(
+            new Collections.Generic.Dictionary<IColumn, IColumn, ICell>(
+                [column],
+                c => c,
+                _ => new Cell(new String(cellText)),
+                c => new ColumnHash(c)
+            )
+        );
+
+        ISchema schema = new Schema.Schema(new String(SchemaName), [table], []);
+
+        IReadOnlyDictionary<ITable, IStoredTableDataSet> datasetsByTable =
+            new Collections.Generic.Dictionary<
+                IStoredTableDataSet,
+                ITable,
+                IStoredTableDataSet
+            >(
+                [new SampleTableDataset(table, [row])],
+                dataset => dataset.TableSchema,
+                dataset => dataset,
+                t => new TableHash(t)
+            );
+
+        return new StoredSchemaDataset(schema, datasetsByTable);
+    }
+
+    [Fact(
+        Skip = "Issue #84: entity resolution consults only the first schema "
+            + "dataset with a matching name, so a from table that lives in a "
+            + "later same-named dataset throws InvalidOperationException "
+            + "instead of resolving."
+    )]
+    [Trait("Status", "KnownGap")]
+    public void FromTableInALaterSameNamedSchemaDatasetResolves()
+    {
+        IStoredSchemaDataSet first = SingleTableDataset(
+            "alpha",
+            "alpha_name",
+            AlphaValue
+        );
+        IStoredSchemaDataSet second = SingleTableDataset(
+            "beta",
+            "beta_name",
+            BetaValue
+        );
+
+        Query query = new Query(
+            new FromExpression($"{SchemaName}.beta"),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField($"{SchemaName}.beta", "beta_name")
+                        )
+                    )
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection([first, second], query)
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(BetaValue, result.Row(0)["beta_name"]);
+    }
+
+    [Fact(
+        Skip = "Issue #84: join resolution consults only the first schema "
+            + "dataset with a matching name, so a join table that lives in a "
+            + "later same-named dataset throws InvalidOperationException "
+            + "instead of resolving."
+    )]
+    [Trait("Status", "KnownGap")]
+    public void JoinTableInALaterSameNamedSchemaDatasetResolves()
+    {
+        IStoredSchemaDataSet first = SingleTableDataset(
+            "alpha",
+            "alpha_name",
+            AlphaValue
+        );
+        IStoredSchemaDataSet second = SingleTableDataset(
+            "beta",
+            "beta_name",
+            BetaValue
+        );
+
+        Query query = new Query(
+            new FromExpression($"{SchemaName}.alpha"),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField($"{SchemaName}.beta", "beta_name")
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Inner,
+                    $"{SchemaName}.beta",
+                    new BooleanReturning(new BooleanScalar(true))
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection([first, second], query)
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(BetaValue, result.Row(0)["beta_name"]);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Combined/FullPipelineTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Combined/FullPipelineTests.cs
@@ -1,0 +1,168 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+using ModelPagination = PureQL.CSharp.Model.Pagination;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Combined;
+
+// Every clause at once, in pipeline order: JOIN -> WHERE -> ORDER BY ->
+// GROUP BY -> HAVING -> projection -> pagination. The expected window is
+// computed step-by-step from the ground-truth records.
+[Trait("Clause", "Combined")]
+[Trait("Feature", "FullPipeline")]
+public sealed class FullPipelineTests
+{
+    [Fact]
+    public void JoinWhereGroupByHavingOrderByPaginationCompose()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "orderCount"
+                ),
+            ],
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachBooleanEquality(
+                        new BooleanArrayReturning(
+                            new BooleanField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Active
+                            )
+                        ),
+                        new BooleanReturning(new BooleanScalar(true))
+                    )
+                )
+            ),
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                ),
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
+            [
+                new Field(
+                    new StringField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.Status
+                    )
+                ),
+            ],
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.GreaterThan,
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(1))
+                    )
+                )
+            ),
+            [
+                new OrderByItem(
+                    new Field(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    SortDirection.Asc
+                ),
+            ],
+            new ModelPagination(1, 2)
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string, double)[] expected =
+        [
+            .. db.OrderRows
+                .Where(order =>
+                    db.UserRows.Single(user =>
+                        user.UserId == order.OrderUserId
+                    ).UserActive
+                )
+                .GroupBy(order => order.OrderStatus)
+                .Where(group => group.Count() > 1)
+                .OrderBy(group => group.Key, StringComparer.Ordinal)
+                .Select(group => (group.Key, (double)group.Count()))
+                .Skip(1)
+                .Take(2),
+        ];
+
+        (string, double)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (
+                    row[SampleDatabase.Orders.Status]!,
+                    row.Double("orderCount")!.Value
+                )
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/CrossEntityGroupByTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/CrossEntityGroupByTests.cs
@@ -1,0 +1,207 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.GroupBy;
+
+// GROUP BY over a join: keys may come from both sides of the join
+// (entity-qualified), and aggregates may fold columns of the other side.
+// Uses the colliding-name dataset so entity qualification is load-bearing.
+[Trait("Clause", "GroupBy")]
+[Trait("Feature", "CrossEntityGroupBy")]
+public sealed class CrossEntityGroupByTests
+{
+    private static Join NeedsToEstimatesJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            CollidingNameDatabase.Estimates.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Estimates.Entity,
+                                CollidingNameDatabase.Estimates.NeedId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void GroupByKeysFromBothTablesYieldsDistinctCombinations()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.SpecialtyId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                CollidingNameDatabase.Estimates.Entity,
+                                CollidingNameDatabase.Estimates.Status
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [NeedsToEstimatesJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        CollidingNameDatabase.Needs.Entity,
+                        CollidingNameDatabase.Needs.SpecialtyId
+                    )
+                ),
+                new Field(
+                    new StringField(
+                        CollidingNameDatabase.Estimates.Entity,
+                        CollidingNameDatabase.Estimates.Status
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (Guid, string)[] expected =
+        [
+            .. db.NeedRows
+                .Join(
+                    db.EstimateRows,
+                    need => need.NeedId,
+                    estimate => estimate.EstimateNeedId,
+                    (need, estimate) =>
+                        (need.NeedSpecialtyId, estimate.EstimateStatus)
+                )
+                .Distinct()
+                .OrderBy(pair => pair.NeedSpecialtyId)
+                .ThenBy(pair => pair.EstimateStatus),
+        ];
+
+        (Guid, string)[] actual =
+        [
+            .. result.Rows
+                .Select(row =>
+                    (
+                        SpecialtyId: row
+                            .Uuid(CollidingNameDatabase.Needs.SpecialtyId)!
+                            .Value,
+                        Status: row[CollidingNameDatabase.Estimates.Status]!
+                    )
+                )
+                .OrderBy(pair => pair.SpecialtyId)
+                .ThenBy(pair => pair.Status),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void GroupByJoinedKeyAggregatesBaseTableValues()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                CollidingNameDatabase.Estimates.Entity,
+                                CollidingNameDatabase.Estimates.Status
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            CollidingNameDatabase.Needs.Entity,
+                                            CollidingNameDatabase.Needs.PlannedHours
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "plannedSum"
+                ),
+            ],
+            where: null,
+            [NeedsToEstimatesJoin()],
+            [
+                new Field(
+                    new StringField(
+                        CollidingNameDatabase.Estimates.Entity,
+                        CollidingNameDatabase.Estimates.Status
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<string, double> expected = db.NeedRows
+            .Join(
+                db.EstimateRows,
+                need => need.NeedId,
+                estimate => estimate.EstimateNeedId,
+                (need, estimate) =>
+                    (estimate.EstimateStatus, need.NeedPlannedHours)
+            )
+            .GroupBy(pair => pair.EstimateStatus)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Sum(pair => pair.NeedPlannedHours)
+            );
+
+        Dictionary<string, double> actual = result.Rows.ToDictionary(
+            row => row[CollidingNameDatabase.Estimates.Status]!,
+            row => row.Double("plannedSum")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/HavingCompositeTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/HavingCompositeTests.cs
@@ -1,0 +1,218 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.BooleanOperations;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.Equalities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.GroupBy;
+
+// HAVING composed with and / or / not over aggregate comparisons, plus
+// equality between two aggregates of the same group. Orders are grouped by
+// their user; expected groups are computed from the ground-truth records.
+[Trait("Clause", "GroupBy")]
+[Trait("Feature", "Having")]
+public sealed class HavingCompositeTests
+{
+    private static NumberReturning OrderCount()
+    {
+        return new NumberReturning(
+            new Count(
+                new ArrayReturning(
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Id
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static NumberArrayReturning Totals()
+    {
+        return new NumberArrayReturning(
+            new NumberField(
+                SampleDatabase.Orders.Entity,
+                SampleDatabase.Orders.Total
+            )
+        );
+    }
+
+    private static NumberReturning MinTotal()
+    {
+        return new NumberReturning(new NumberAggregate(new MinNumber(Totals())));
+    }
+
+    private static NumberReturning MaxTotal()
+    {
+        return new NumberReturning(new NumberAggregate(new MaxNumber(Totals())));
+    }
+
+    private static BooleanReturning CountGreaterThan(double threshold)
+    {
+        return new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    ComparisonOperator.GreaterThan,
+                    OrderCount(),
+                    new NumberReturning(new NumberScalar(threshold))
+                )
+            )
+        );
+    }
+
+    private static BooleanReturning MaxTotalAtLeast(double threshold)
+    {
+        return new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    ComparisonOperator.GreaterThanOrEqual,
+                    MaxTotal(),
+                    new NumberReturning(new NumberScalar(threshold))
+                )
+            )
+        );
+    }
+
+    private static Query OrdersGroupedByUser(BooleanReturning having)
+    {
+        return new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            having,
+            orderBy: null,
+            pagination: null
+        );
+    }
+
+    [Fact]
+    public void HavingAndOfTwoAggregateComparisonsRequiresBoth()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new BooleanOperator(
+                    new AndOperator([CountGreaterThan(1), MaxTotalAtLeast(200)])
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expected = db.OrderRows
+            .GroupBy(order => order.OrderUserId)
+            .Count(group =>
+                group.Count() > 1 && group.Max(order => order.OrderTotal) >= 200
+            );
+
+        Assert.Equal(expected, result.Count);
+    }
+
+    [Fact]
+    public void HavingOrOfTwoAggregateComparisonsAcceptsEither()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new BooleanOperator(
+                    new OrOperator([CountGreaterThan(1), MaxTotalAtLeast(200)])
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expected = db.OrderRows
+            .GroupBy(order => order.OrderUserId)
+            .Count(group =>
+                group.Count() > 1 || group.Max(order => order.OrderTotal) >= 200
+            );
+
+        Assert.Equal(expected, result.Count);
+    }
+
+    [Fact]
+    public void HavingNotInvertsAnAggregateComparison()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new BooleanOperator(new NotOperator(CountGreaterThan(1)))
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expected = db.OrderRows
+            .GroupBy(order => order.OrderUserId)
+            .Count(group => group.Count() <= 1);
+
+        Assert.Equal(expected, result.Count);
+    }
+
+    [Fact]
+    public void HavingEqualityOfMinAndMaxKeepsConstantGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new Equality(
+                    new SingleValueEquality(
+                        new NumberEquality(MinTotal(), MaxTotal())
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expected = db.OrderRows
+            .GroupBy(order => order.OrderUserId)
+            .Count(group =>
+                group.Min(order => order.OrderTotal)
+                == group.Max(order => order.OrderTotal)
+            );
+
+        Assert.Equal(expected, result.Count);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/HavingWithoutGroupByTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/HavingWithoutGroupByTests.cs
@@ -1,0 +1,161 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.GroupBy;
+
+#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
+
+// HAVING with no groupBy is schema-valid (SQL-style implicit whole-set
+// group). It is honoured today only when the select list contains an
+// aggregate (which engages group mode); with plain field selects the clause
+// is silently dropped (issue #83).
+[Trait("Clause", "GroupBy")]
+[Trait("Feature", "Having")]
+public sealed class HavingWithoutGroupByTests
+{
+    private static BooleanReturning UserCountComparedTo(
+        ComparisonOperator comparisonOperator,
+        double threshold
+    )
+    {
+        return new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    comparisonOperator,
+                    new NumberReturning(
+                        new Count(
+                            new ArrayReturning(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(threshold))
+                )
+            )
+        );
+    }
+
+    private static SelectExpression CountOfUserIds(string alias)
+    {
+        return new SelectExpression(
+            new SingleValueReturning(
+                new NumberReturning(
+                    new Count(
+                        new ArrayReturning(
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.Id
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            alias
+        );
+    }
+
+    [Fact(
+        Skip = "Issue #83: with no groupBy and no aggregate select the query "
+            + "never enters group mode, so HAVING is silently dropped and a "
+            + "constant-false condition still returns every row."
+    )]
+    [Trait("Status", "KnownGap")]
+    public void HavingWithoutGroupByFiltersTheImplicitWholeSetGroup()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            new BooleanReturning(new BooleanScalar(false)),
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    [Fact]
+    public void WholeSetHavingKeepsTheSingleGroupWhenSatisfied()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [CountOfUserIds("userCount")],
+            where: null,
+            join: null,
+            groupBy: null,
+            UserCountComparedTo(
+                ComparisonOperator.GreaterThanOrEqual,
+                db.UserRows.Count
+            ),
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(db.UserRows.Count, result.Row(0).Double("userCount"));
+    }
+
+    [Fact]
+    public void WholeSetHavingRemovesTheSingleGroupWhenUnsatisfied()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [CountOfUserIds("userCount")],
+            where: null,
+            join: null,
+            groupBy: null,
+            UserCountComparedTo(
+                ComparisonOperator.GreaterThan,
+                db.UserRows.Count
+            ),
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/ChainedOuterJoinPaddingTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/ChainedOuterJoinPaddingTests.cs
@@ -1,0 +1,151 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+// Two chained LEFT joins: padding must propagate. A row padded by the first
+// join carries empty cells for the middle table, so the second join's key
+// equality can never match it and it must be padded again, surviving to the
+// final result exactly once.
+[Trait("Clause", "Join")]
+[Trait("Feature", "ChainedOuterJoin")]
+public sealed class ChainedOuterJoinPaddingTests
+{
+    private static Join UsersToOrdersLeftJoin()
+    {
+        return new Join(
+            JoinType.Left,
+            SampleDatabase.Orders.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static Join OrdersToItemsLeftJoin()
+    {
+        return new Join(
+            JoinType.Left,
+            SampleDatabase.OrderItems.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.OrderId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void SecondLeftJoinPadsRowsAlreadyPaddedByTheFirst()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [UsersToOrdersLeftJoin(), OrdersToItemsLeftJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedCount = db.UserRows.Sum(user =>
+        {
+            List<OrderRow> orders =
+            [
+                .. db.OrderRows.Where(order =>
+                    order.OrderUserId == user.UserId
+                ),
+            ];
+
+            return orders.Count == 0
+                ? 1
+                : orders.Sum(order =>
+                    Math.Max(
+                        1,
+                        db.OrderItemRows.Count(item =>
+                            item.ItemOrderId == order.OrderId
+                        )
+                    )
+                );
+        });
+
+        Assert.Equal(expectedCount, result.Count);
+
+        foreach (UserRow user in db.UserRows)
+        {
+            List<OrderRow> orders =
+            [
+                .. db.OrderRows.Where(order =>
+                    order.OrderUserId == user.UserId
+                ),
+            ];
+
+            int expectedAppearances = orders.Count == 0
+                ? 1
+                : orders.Sum(order =>
+                    Math.Max(
+                        1,
+                        db.OrderItemRows.Count(item =>
+                            item.ItemOrderId == order.OrderId
+                        )
+                    )
+                );
+
+            Assert.Equal(
+                expectedAppearances,
+                result
+                    .Column(SampleDatabase.Users.Name)
+                    .Count(name => name == user.UserName)
+            );
+        }
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/CompositeOuterJoinConditionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/CompositeOuterJoinConditionTests.cs
@@ -1,0 +1,204 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachBooleanOperations;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+// Composite per-row on conditions (and / or / not around equalities and
+// comparisons) on inner and outer joins. Expected row sets are computed
+// pair-by-pair from the ground-truth records.
+[Trait("Clause", "Join")]
+[Trait("Feature", "CompositeCondition")]
+public sealed class CompositeOuterJoinConditionTests
+{
+    private static BooleanArrayReturning UserKeyMatch()
+    {
+        return new BooleanArrayReturning(
+            new EachEquality(
+                new EachUuidEquality(
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Users.Entity,
+                            SampleDatabase.Users.Id
+                        )
+                    ),
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.UserId
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static BooleanArrayReturning TotalGreaterThan(double threshold)
+    {
+        return new BooleanArrayReturning(
+            new EachComparison(
+                new EachNumberComparison(
+                    EachComparisonOperator.EachGreaterThan,
+                    new NumberArrayReturning(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(threshold))
+                )
+            )
+        );
+    }
+
+    private static Query UsersJoinedToOrders(
+        JoinType joinType,
+        BooleanArrayReturning onCondition
+    )
+    {
+        return new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [new Join(joinType, SampleDatabase.Orders.Entity, onCondition)],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+    }
+
+    [Fact]
+    public void LeftJoinOnKeyAndThresholdPadsUsersWithoutQualifyingOrders()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        const double threshold = 100;
+
+        Query query = UsersJoinedToOrders(
+            JoinType.Left,
+            new BooleanArrayReturning(
+                new EachAndOperator([UserKeyMatch(), TotalGreaterThan(threshold)])
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedCount = db.UserRows.Sum(user =>
+            Math.Max(
+                1,
+                db.OrderRows.Count(order =>
+                    order.OrderUserId == user.UserId
+                    && order.OrderTotal > threshold
+                )
+            )
+        );
+
+        Assert.Equal(expectedCount, result.Count);
+
+        foreach (UserRow user in db.UserRows)
+        {
+            int expectedAppearances = Math.Max(
+                1,
+                db.OrderRows.Count(order =>
+                    order.OrderUserId == user.UserId
+                    && order.OrderTotal > threshold
+                )
+            );
+
+            Assert.Equal(
+                expectedAppearances,
+                result
+                    .Column(SampleDatabase.Users.Name)
+                    .Count(name => name == user.UserName)
+            );
+        }
+    }
+
+    [Fact]
+    public void InnerJoinOnDisjunctiveConditionKeepsEitherMatch()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        const double markerTotal = 200;
+
+        Query query = UsersJoinedToOrders(
+            JoinType.Inner,
+            new BooleanArrayReturning(
+                new EachOrOperator(
+                    [
+                        UserKeyMatch(),
+                        new BooleanArrayReturning(
+                            new EachEquality(
+                                new EachNumberEquality(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    ),
+                                    new NumberReturning(
+                                        new NumberScalar(markerTotal)
+                                    )
+                                )
+                            )
+                        ),
+                    ]
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedCount = db.UserRows.Sum(user =>
+            db.OrderRows.Count(order =>
+                order.OrderUserId == user.UserId
+                || order.OrderTotal == markerTotal
+            )
+        );
+
+        Assert.Equal(expectedCount, result.Count);
+    }
+
+    [Fact]
+    public void InnerJoinOnNegatedKeyEqualityKeepsOnlyNonMatchingPairs()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = UsersJoinedToOrders(
+            JoinType.Inner,
+            new BooleanArrayReturning(new EachNotOperator(UserKeyMatch()))
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedCount = db.UserRows.Sum(user =>
+            db.OrderRows.Count(order => order.OrderUserId != user.UserId)
+        );
+
+        Assert.Equal(expectedCount, result.Count);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinOnConstantConditionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinOnConstantConditionTests.cs
@@ -1,0 +1,118 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+// A join's on clause may be a single boolean-returning expression; constant
+// conditions pin the degenerate join shapes: true yields the full cross
+// product, false yields no matches (empty for INNER, fully padded for the
+// outer types).
+[Trait("Clause", "Join")]
+[Trait("Feature", "ConstantCondition")]
+public sealed class JoinOnConstantConditionTests
+{
+    private static Query UsersJoinedToProducts(JoinType joinType, bool condition)
+    {
+        return new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    joinType,
+                    SampleDatabase.Products.Entity,
+                    new BooleanReturning(new BooleanScalar(condition))
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+    }
+
+    [Fact]
+    public void InnerJoinOnConstantTrueProducesTheCrossProduct()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                UsersJoinedToProducts(JoinType.Inner, condition: true)
+            )
+        );
+
+        Assert.Equal(db.UserRows.Count * db.ProductRows.Count, result.Count);
+    }
+
+    [Fact]
+    public void InnerJoinOnConstantFalseReturnsEmpty()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                UsersJoinedToProducts(JoinType.Inner, condition: false)
+            )
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    [Fact]
+    public void LeftJoinOnConstantFalsePadsEveryLeftRowOnce()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                UsersJoinedToProducts(JoinType.Left, condition: false)
+            )
+        );
+
+        Assert.Equal(db.UserRows.Count, result.Count);
+
+        string[] expected =
+        [
+            .. db.UserRows.Select(user => user.UserName).OrderBy(name => name),
+        ];
+
+        Assert.Equal(
+            expected,
+            result.Column(SampleDatabase.Users.Name).OrderBy(name => name).ToArray()
+        );
+    }
+
+    [Fact]
+    public void FullJoinOnConstantFalseKeepsEverySideUnmatched()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                UsersJoinedToProducts(JoinType.Full, condition: false)
+            )
+        );
+
+        Assert.Equal(db.UserRows.Count + db.ProductRows.Count, result.Count);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/OuterJoinAggregationTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/OuterJoinAggregationTests.cs
@@ -1,0 +1,202 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+// Aggregates evaluated over an outer join: unmatched left rows carry empty
+// cells for the joined side, and SQL count/sum semantics skip those absent
+// values, so aggregates over a joined column see only the matched rows.
+[Trait("Clause", "Join")]
+[Trait("Feature", "OuterJoinAggregation")]
+public sealed class OuterJoinAggregationTests
+{
+    private static Join UsersToOrdersLeftJoin()
+    {
+        return new Join(
+            JoinType.Left,
+            SampleDatabase.Orders.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void CountOverJoinedColumnAfterLeftJoinCountsOnlyMatchedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "orderCount"
+                ),
+            ],
+            where: null,
+            [UsersToOrdersLeftJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        // Every order matches a user; the padded row of the orderless user
+        // must not contribute to the count.
+        Assert.Equal(1, result.Count);
+        Assert.Equal(db.OrderRows.Count, result.Row(0).Double("orderCount"));
+    }
+
+    [Fact]
+    public void LeftJoinGroupByUserCountsZeroForUnmatchedUsers()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "orderCount"
+                ),
+            ],
+            where: null,
+            [UsersToOrdersLeftJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Users.Entity,
+                        SampleDatabase.Users.Id
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = db.UserRows.ToDictionary(
+            user => user.UserId,
+            user => (double)
+                db.OrderRows.Count(order => order.OrderUserId == user.UserId)
+        );
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Users.Id)!.Value,
+            row => row.Double("orderCount")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SumOverJoinedColumnAfterLeftJoinIgnoresPaddedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "totalSum"
+                ),
+            ],
+            where: null,
+            [UsersToOrdersLeftJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(
+            db.OrderRows.Sum(order => order.OrderTotal),
+            result.Row(0).Double("totalSum")
+        );
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/UndeclaredAliasEntityTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/UndeclaredAliasEntityTests.cs
@@ -1,0 +1,219 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
+
+// The spec gives joinItem no alias: joined tables must be referenced by
+// their full "schema.table" entity string, and only the root from supports
+// an alias. A field reference whose entity matches neither the from
+// entity/alias nor any join entity is unresolvable and must fail fast
+// instead of silently degrading to bare-name resolution (issue #82). The
+// passing tests pin the spec-legal from-alias references.
+[Trait("Clause", "Join")]
+[Trait("Feature", "AliasResolution")]
+public sealed class UndeclaredAliasEntityTests
+{
+    private static Join NeedsToSpecialtiesJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            CollidingNameDatabase.Specialties.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.SpecialtyId
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Specialties.Entity,
+                                CollidingNameDatabase.Specialties.Id
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact(
+        Skip = "Issue #82: a join-on field reference via an undeclared join "
+            + "alias silently binds to the base table's same-named column, "
+            + "so the equi-join key never matches and the join returns an "
+            + "empty result instead of failing fast."
+    )]
+    [Trait("Status", "KnownGap")]
+    public void JoinOnConditionViaUndeclaredAliasFailsFast()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity, "need"),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                CollidingNameDatabase.Needs.Entity,
+                                CollidingNameDatabase.Needs.Id
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Inner,
+                    CollidingNameDatabase.Specialties.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        CollidingNameDatabase.Needs.Entity,
+                                        CollidingNameDatabase.Needs.SpecialtyId
+                                    )
+                                ),
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        "sp",
+                                        CollidingNameDatabase.Specialties.Id
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+
+    [Fact(
+        Skip = "Issue #82: selecting a colliding column via an undeclared "
+            + "join alias silently returns the base table's values instead "
+            + "of failing fast."
+    )]
+    [Trait("Status", "KnownGap")]
+    public void SelectOfCollidingColumnViaUndeclaredAliasFailsFast()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity, "need"),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField("sp", CollidingNameDatabase.Specialties.Id)
+                        )
+                    ),
+                    "specId"
+                ),
+            ],
+            where: null,
+            [NeedsToSpecialtiesJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+
+    [Fact]
+    public void FromAliasFieldReferenceResolvesWithoutJoins()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity, "u"),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField("u", SampleDatabase.Users.Name)
+                        )
+                    )
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.UserRows.Select(user => user.UserName).OrderBy(name => name),
+        ];
+
+        Assert.Equal(
+            expected,
+            result.Column(SampleDatabase.Users.Name).OrderBy(name => name).ToArray()
+        );
+    }
+
+    [Fact]
+    public void FromAliasReferenceToCollidingColumnResolvesToTheBaseTable()
+    {
+        CollidingNameDatabase db = new CollidingNameDatabase();
+
+        Query query = new Query(
+            new FromExpression(CollidingNameDatabase.Needs.Entity, "need"),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField("need", CollidingNameDatabase.Needs.Id)
+                        )
+                    ),
+                    "ownId"
+                ),
+            ],
+            where: null,
+            [NeedsToSpecialtiesJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Guid[] expected =
+        [
+            .. db.NeedRows.Select(need => need.NeedId).OrderBy(id => id),
+        ];
+
+        Guid[] actual =
+        [
+            .. result.Rows
+                .Select(row => row.Uuid("ownId")!.Value)
+                .OrderBy(id => id),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/OrderBy/OrderByJoinedColumnTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/OrderBy/OrderByJoinedColumnTests.cs
@@ -1,0 +1,126 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.OrderBy;
+
+// ORDER BY over a joined (entity-qualified) column: the primary key comes
+// from the joined table, the secondary key from the base table, so ordering
+// must resolve both sides of the merged row.
+[Trait("Clause", "OrderBy")]
+[Trait("Feature", "JoinedColumn")]
+public sealed class OrderByJoinedColumnTests
+{
+    [Fact]
+    public void OrderByJoinedNameThenBaseTotalDescOrdersMergedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                ),
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new StringField(
+                            SampleDatabase.Users.Entity,
+                            SampleDatabase.Users.Name
+                        )
+                    ),
+                    SortDirection.Asc
+                ),
+                new OrderByItem(
+                    new Field(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    SortDirection.Desc
+                ),
+            ],
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string, double)[] expected =
+        [
+            .. db.OrderRows
+                .Select(order =>
+                    (
+                        Name: db.UserRows.Single(user =>
+                            user.UserId == order.OrderUserId
+                        ).UserName,
+                        Total: order.OrderTotal
+                    )
+                )
+                .OrderBy(pair => pair.Name, StringComparer.Ordinal)
+                .ThenByDescending(pair => pair.Total),
+        ];
+
+        (string, double)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (
+                    row[SampleDatabase.Users.Name]!,
+                    row.Double(SampleDatabase.Orders.Total)!.Value
+                )
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Pagination/PaginationRangeTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Pagination/PaginationRangeTests.cs
@@ -1,0 +1,82 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Fields;
+using ModelPagination = PureQL.CSharp.Model.Pagination;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Pagination;
+
+#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
+
+// Pagination carries skip/take as Int64, but they are applied through an
+// unchecked cast to Int32, so values beyond int.MaxValue wrap and silently
+// produce the wrong window (issue #85).
+[Trait("Clause", "Pagination")]
+[Trait("Feature", "Range")]
+public sealed class PaginationRangeTests
+{
+    private static Query AllUserNames(ModelPagination pagination)
+    {
+        return new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination
+        );
+    }
+
+    [Fact(
+        Skip = "Issue #85: take = long.MaxValue wraps to -1 through the "
+            + "unchecked int cast, so a query asking for everything returns "
+            + "an empty result."
+    )]
+    [Trait("Status", "KnownGap")]
+    public void TakeBeyondIntMaxReturnsEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                AllUserNames(new ModelPagination(0, long.MaxValue))
+            )
+        );
+
+        Assert.Equal(db.UserRows.Count, result.Count);
+    }
+
+    [Fact(
+        Skip = "Issue #85: skip = long.MaxValue wraps to -1 through the "
+            + "unchecked int cast, making the skip a no-op, so rows that "
+            + "should all be skipped are returned."
+    )]
+    [Trait("Status", "KnownGap")]
+    public void SkipBeyondIntMaxReturnsNoRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                AllUserNames(new ModelPagination(long.MaxValue, 1))
+            )
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/DistinctOverJoinTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/DistinctOverJoinTests.cs
@@ -1,0 +1,133 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Select;
+
+// SELECT DISTINCT deduplicates the projected rows after a join fans the
+// base rows out, so duplicates introduced by the join collapse back to the
+// distinct projected value set.
+[Trait("Clause", "Select")]
+[Trait("Feature", "Distinct")]
+public sealed class DistinctOverJoinTests
+{
+    private static Join UsersToOrdersInnerJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Orders.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static Query DistinctColumnThroughJoin(SelectExpression select)
+    {
+        return new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [select],
+            where: null,
+            [UsersToOrdersInnerJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+    }
+
+    [Fact]
+    public void DistinctCollapsesJoinFanOutDuplicates()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = DistinctColumnThroughJoin(
+            new SelectExpression(
+                new ArrayReturning(
+                    new StringArrayReturning(
+                        new StringField(
+                            SampleDatabase.Users.Entity,
+                            SampleDatabase.Users.Name
+                        )
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.UserRows
+                .Where(user =>
+                    db.OrderRows.Any(order => order.OrderUserId == user.UserId)
+                )
+                .Select(user => user.UserName)
+                .OrderBy(name => name),
+        ];
+
+        Assert.Equal(
+            expected,
+            result.Column(SampleDatabase.Users.Name).OrderBy(name => name).ToArray()
+        );
+    }
+
+    [Fact]
+    public void DistinctOnJoinedColumnCollapsesToItsDistinctValues()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = DistinctColumnThroughJoin(
+            new SelectExpression(
+                new ArrayReturning(
+                    new StringArrayReturning(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.OrderRows
+                .Select(order => order.OrderStatus)
+                .Distinct()
+                .OrderBy(status => status),
+        ];
+
+        Assert.Equal(
+            expected,
+            result
+                .Column(SampleDatabase.Orders.Status)
+                .OrderBy(status => status)
+                .ToArray()
+        );
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/DistinctPaginationOrderTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/DistinctPaginationOrderTests.cs
@@ -1,0 +1,98 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using ModelPagination = PureQL.CSharp.Model.Pagination;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Select;
+
+// Pipeline-order pin: DISTINCT deduplicates the projected rows before
+// pagination slices them, and ordering applied upstream survives the
+// deduplication (first-seen order of ordered rows is sorted order), so the
+// window addresses the sorted distinct values, not the raw fan-out.
+[Trait("Clause", "Select")]
+[Trait("Feature", "Distinct")]
+public sealed class DistinctPaginationOrderTests
+{
+    [Fact]
+    public void PaginationWindowsTheSortedDistinctValuesAfterJoinFanOut()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Orders.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                ),
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    SortDirection.Asc
+                ),
+            ],
+            new ModelPagination(1, 1),
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.OrderRows
+                .Select(order => order.OrderStatus)
+                .Distinct()
+                .OrderBy(status => status, StringComparer.Ordinal)
+                .Skip(1)
+                .Take(1),
+        ];
+
+        Assert.Equal(
+            expected,
+            result.Column(SampleDatabase.Orders.Status).ToArray()
+        );
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/CrossEntityTemporalArithmeticTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/CrossEntityTemporalArithmeticTests.cs
@@ -1,0 +1,127 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachDateArithmetics;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// Per-row temporal arithmetic whose operands come from both sides of a
+// join: eachDateDiffDays(order date, user signup date) computes a per-row
+// day gap across the merged row, then feeds a numeric comparison.
+[Trait("Clause", "Where")]
+[Trait("Feature", "EachDateArithmetic")]
+public sealed class CrossEntityTemporalArithmeticTests
+{
+    [Fact]
+    public void EachDateDiffDaysAcrossJoinedTablesFiltersByTheGap()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        const double thresholdDays = 1200;
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Id
+                            )
+                        )
+                    )
+                ),
+            ],
+            new BooleanArrayReturning(
+                new EachComparison(
+                    new EachNumberComparison(
+                        EachComparisonOperator.EachGreaterThan,
+                        new NumberArrayReturning(
+                            new EachDateDiffDays(
+                                new DateArrayReturning(
+                                    new DateField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.PlacedOn
+                                    )
+                                ),
+                                new DateArrayReturning(
+                                    new DateField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.SignupDate
+                                    )
+                                )
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(thresholdDays))
+                    )
+                )
+            ),
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                ),
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Guid[] expected =
+        [
+            .. db.OrderRows
+                .Where(order =>
+                {
+                    UserRow user = db.UserRows.Single(candidate =>
+                        candidate.UserId == order.OrderUserId
+                    );
+
+                    int gap = order.PlacedOn.DayNumber
+                        - user.SignupDate.DayNumber;
+
+                    return gap > thresholdDays;
+                })
+                .Select(order => order.OrderId)
+                .OrderBy(id => id),
+        ];
+
+        Guid[] actual =
+        [
+            .. result.Rows
+                .Select(row => row.Uuid(SampleDatabase.Orders.Id)!.Value)
+                .OrderBy(id => id),
+        ];
+
+        Assert.NotEmpty(expected);
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/JoinedFilterTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/JoinedFilterTests.cs
@@ -1,0 +1,200 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachBooleanOperations;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where;
+
+// WHERE evaluated over merged join rows: predicates may mix columns of both
+// tables, reference a joined boolean field directly, or negate a condition
+// on the joined side. Expected sets are computed pair-by-pair from the
+// ground-truth records.
+[Trait("Clause", "Where")]
+[Trait("Feature", "JoinedFilter")]
+public sealed class JoinedFilterTests
+{
+    private static Join OrdersToUsersJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Users.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static Query OrdersWithUsers(BooleanArrayReturning where)
+    {
+        return new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Id
+                            )
+                        )
+                    )
+                ),
+            ],
+            where,
+            [OrdersToUsersJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+    }
+
+    private static UserRow UserOf(SampleDatabase db, OrderRow order)
+    {
+        return db.UserRows.Single(user => user.UserId == order.OrderUserId);
+    }
+
+    [Fact]
+    public void WhereConjunctionAcrossBothTablesFiltersMergedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        const double ageThreshold = 30;
+        const double totalThreshold = 100;
+
+        Query query = OrdersWithUsers(
+            new BooleanArrayReturning(
+                new EachAndOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachComparison(
+                                new EachNumberComparison(
+                                    EachComparisonOperator.EachGreaterThanOrEqual,
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Users.Entity,
+                                            SampleDatabase.Users.Age
+                                        )
+                                    ),
+                                    new NumberReturning(
+                                        new NumberScalar(ageThreshold)
+                                    )
+                                )
+                            )
+                        ),
+                        new BooleanArrayReturning(
+                            new EachComparison(
+                                new EachNumberComparison(
+                                    EachComparisonOperator.EachGreaterThan,
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    ),
+                                    new NumberReturning(
+                                        new NumberScalar(totalThreshold)
+                                    )
+                                )
+                            )
+                        ),
+                    ]
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expected = db.OrderRows.Count(order =>
+            UserOf(db, order).UserAge >= ageThreshold
+            && order.OrderTotal > totalThreshold
+        );
+
+        Assert.Equal(expected, result.Count);
+    }
+
+    [Fact]
+    public void WhereOnJoinedBooleanFieldKeepsRowsWhereItIsTrue()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersWithUsers(
+            new BooleanArrayReturning(
+                new BooleanField(
+                    SampleDatabase.Users.Entity,
+                    SampleDatabase.Users.Active
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expected = db.OrderRows.Count(order => UserOf(db, order).UserActive);
+
+        Assert.Equal(expected, result.Count);
+    }
+
+    [Fact]
+    public void WhereNegationOnJoinedColumnExcludesItsRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        const string excludedName = "Ann";
+
+        Query query = OrdersWithUsers(
+            new BooleanArrayReturning(
+                new EachNotOperator(
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachStringEquality(
+                                new StringArrayReturning(
+                                    new StringField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Name
+                                    )
+                                ),
+                                new StringReturning(
+                                    new StringScalar(excludedName)
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expected = db.OrderRows.Count(order =>
+            UserOf(db, order).UserName != excludedName
+        );
+
+        Assert.Equal(expected, result.Count);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 18 test files (35 tests: 28 passing, 7 skipped known-gap reproductions) strengthening coverage of joins, filtration, join conditions, single-value returnings and GROUP BY — and pins four newly found translator bugs (#82, #83, #84, #85) as skipped reproduction tests, following the existing `[Fact(Skip = ...)]` + `Trait("Status", "KnownGap")` convention.

## New passing coverage

- **Joins / conditions**
  - `JoinOnConstantConditionTests` — degenerate on-clauses: constant `true` → full cross product; constant `false` → empty (INNER), one padded row per left row (LEFT), both sides unmatched (FULL).
  - `CompositeOuterJoinConditionTests` — `eachAnd` of key equality + numeric threshold on a LEFT join (padding when no order qualifies), `eachOr` disjunction and `eachNot` negation on INNER joins; expected sets computed pair-by-pair from ground truth.
  - `OuterJoinAggregationTests` — SQL null-skipping semantics over outer joins: whole-set `count`/`sum` over a joined column ignore padded rows; per-user grouped counts report 0 for users without orders.
  - `UndeclaredAliasEntityTests` (passing part) — from-alias field references resolve correctly, including to the base table's colliding column after a join.
- **Filtration**
  - `Where/JoinedFilterTests` — WHERE over merged join rows: conjunction across both tables' columns, a joined boolean field used directly as the predicate, `eachNot` on the joined side.
- **Single-value returnings**
  - `AggregateOverPerRowArithmeticTests` — `sum(qty * price)` across a join, per-group and whole-set.
  - `HavingCompositeTests` — `and`/`or`/`not` over aggregate comparisons; equality between two aggregates (`min == max` keeps constant groups).
  - `HavingWithoutGroupByTests` (passing part) — whole-set HAVING works when the select list has an aggregate.
- **GROUP BY**
  - `CrossEntityGroupByTests` — composite keys drawn from both sides of a join and aggregates folding the other side's column, on the colliding-name dataset so entity qualification is load-bearing.
- **Pipeline & projection**
  - `Combined/FullPipelineTests` — JOIN → WHERE → GROUP BY → HAVING → ORDER BY → pagination in one query, expected window computed step-by-step.
  - `Select/DistinctOverJoinTests` — SELECT DISTINCT collapses join fan-out duplicates.

- **Second batch**
  - `Joins/ChainedOuterJoinPaddingTests` — padding propagates through two chained LEFT joins (a row padded by the first join can never satisfy the second join's key equality and is padded again).
  - `OrderBy/OrderByJoinedColumnTests` — ORDER BY with the primary key on the joined table and a descending secondary key on the base table, asserted as the full ordered sequence.
  - `Where/Each/CrossEntityTemporalArithmeticTests` — `eachDateDiffDays` with operands from both sides of a join feeding a numeric WHERE comparison.
  - `Aggregates/CrossSchemaJoinAggregateTests` — per-user `max(datetime)` + `count` over `audit.logins` joined onto `shop.users`.
  - `Select/DistinctPaginationOrderTests` — DISTINCT → pagination pipeline order over a sorted join fan-out.

## Skipped known-gap reproductions (issues filed)

| Issue | Test | Symptom today |
| --- | --- | --- |
| #82 | `Joins/UndeclaredAliasEntityTests` | Field references via an undeclared join alias silently bind to the base table's same-named column: alias in the on-clause → join matches nothing (empty result); alias in select over a colliding name → base table's values byte-for-byte. This is the alias-shaped residue of #77: the entity-qualified fix only protects full `schema.table` references, while the wire model (`JoinConverter`) silently drops `"alias"` on joins. |
| #83 | `GroupBy/HavingWithoutGroupByTests` | With no `groupBy` and no aggregate select, group mode never engages and HAVING is silently dropped — a constant-`false` having still returns every row. |
| #84 | `Api/DuplicateSchemaNameTests` | Entity resolution consults only the *first* schema dataset with a matching name; a table living in a later same-named dataset throws `InvalidOperationException` (from-table and join-table alike). Relevant to hosts that concatenate datasets from several adapters. |
| #85 | `Pagination/PaginationRangeTests` | `skip`/`take` are `Int64` but applied through an unchecked `int` cast: `take = long.MaxValue` → empty result; `skip = long.MaxValue` → skip becomes a no-op. |

## Verification

- `dotnet build --no-restore -warnaserror` — clean
- `dotnet format --verify-no-changes` — clean
- `dotnet test` — 195 passed, 7 skipped (the known-gap reproductions), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
