### PR TITLE
Fail fast on unknown entities, honour bare HAVING, fix resolution and pagination

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/EntityReferenceValidator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/EntityReferenceValidator.cs
@@ -1,0 +1,513 @@
+using OneOf;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayEqualities;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.BooleanOperations;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.EachArithmetics;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachDateArithmetics;
+using PureQL.CSharp.Model.EachDateTimeArithmetics;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.EachTimeArithmetics;
+using PureQL.CSharp.Model.Equalities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using ModelEquality = PureQL.CSharp.Model.Equality;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection;
+
+// Validates that every field reference in the query addresses a declared
+// entity: the from entity, the from alias, or a join's entity. The spec
+// gives joinItem no alias, so any other entity string (an undeclared join
+// alias, a typo) is unresolvable; failing fast here prevents the silent
+// bare-name fallback that would bind such references to the wrong column.
+internal static class EntityReferenceValidator
+{
+    private static readonly IEnumerable<string> None = [];
+
+    internal static void Validate(Query query)
+    {
+        HashSet<string> known = new(StringComparer.Ordinal) { query.From.Entity };
+
+        if (query.From.Alias is not null)
+        {
+            _ = known.Add(query.From.Alias);
+        }
+
+        if (query.Join is not null)
+        {
+            foreach (Join join in query.Join)
+            {
+                _ = known.Add(join.Entity);
+            }
+        }
+
+        string? unknown = Referenced(query).FirstOrDefault(entity =>
+            !known.Contains(entity)
+        );
+
+        if (unknown is not null)
+        {
+            throw new NotSupportedException(
+                $"Field reference entity '{unknown}' matches neither the "
+                    + "from entity, the from alias, nor any join entity. "
+                    + "Joined tables must be referenced by their full "
+                    + "\"schema.table\" path (joins have no alias)."
+            );
+        }
+    }
+
+    private static IEnumerable<string> Referenced(Query query)
+    {
+        IEnumerable<string> entities = query.SelectExpressions.SelectMany(
+            expression => expression.Match(
+                single => Entities(single),
+                array => Entities(array)
+            )
+        );
+
+        if (query.Where is not null)
+        {
+            entities = entities.Concat(Entities(query.Where.Value));
+        }
+
+        if (query.Join is not null)
+        {
+            entities = entities.Concat(
+                query.Join.SelectMany(join => Entities(join.On))
+            );
+        }
+
+        if (query.GroupBy is not null)
+        {
+            entities = entities.Concat(query.GroupBy.SelectMany(Entities));
+        }
+
+        if (query.Having is not null)
+        {
+            entities = entities.Concat(Entities(query.Having));
+        }
+
+        if (query.OrderBy is not null)
+        {
+            entities = entities.Concat(
+                query.OrderBy.SelectMany(item => Entities(item.Field))
+            );
+        }
+
+        return entities;
+    }
+
+    private static IEnumerable<string> Entities(Field field)
+    {
+        return field.Match(
+            f => One(f.Entity),
+            f => One(f.Entity),
+            f => One(f.Entity),
+            f => One(f.Entity),
+            f => One(f.Entity),
+            f => One(f.Entity),
+            f => One(f.Entity),
+            f => One(f.Entity)
+        );
+    }
+
+    private static IEnumerable<string> One(string entity)
+    {
+        return [entity];
+    }
+
+    // ===== Single-value returnings =====
+
+    private static IEnumerable<string> Entities(SingleValueReturning returning)
+    {
+        return returning.Match(
+            Entities,
+            Entities,
+            Entities,
+            Entities,
+            Entities,
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(BooleanReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            _ => None,
+            Entities,
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(DateReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            _ => None,
+            aggregate => aggregate.Match(
+                max => Entities(max.Argument),
+                min => Entities(min.Argument),
+                average => Entities(average.Argument)
+            )
+        );
+    }
+
+    private static IEnumerable<string> Entities(DateTimeReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            _ => None,
+            aggregate => aggregate.Match(
+                max => Entities(max.Argument),
+                min => Entities(min.Argument),
+                average => Entities(average.Argument)
+            )
+        );
+    }
+
+    private static IEnumerable<string> Entities(TimeReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            _ => None,
+            aggregate => aggregate.Match(
+                max => Entities(max.Argument),
+                min => Entities(min.Argument),
+                average => Entities(average.Argument)
+            )
+        );
+    }
+
+    private static IEnumerable<string> Entities(StringReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            _ => None,
+            aggregate => aggregate.Match(
+                max => Entities(max.Argument),
+                min => Entities(min.Argument)
+            )
+        );
+    }
+
+    private static IEnumerable<string> Entities(NumberReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            _ => None,
+            arithmetic => arithmetic.Match(
+                add => add.Arguments.SelectMany(Entities),
+                divide => divide.Arguments.SelectMany(Entities),
+                multiply => multiply.Arguments.SelectMany(Entities),
+                subtract => subtract.Arguments.SelectMany(Entities)
+            ),
+            aggregate => aggregate.Match(
+                average => Entities(average.Argument),
+                max => Entities(max.Argument),
+                min => Entities(min.Argument),
+                sum => Entities(sum.Argument)
+            ),
+            count => Entities(count.Argument)
+        );
+    }
+
+    private static IEnumerable<string> Entities(UuidReturning returning)
+    {
+        return returning.Match(_ => None, _ => None);
+    }
+
+    // ===== Boolean composites =====
+
+    private static IEnumerable<string> Entities(ModelEquality equality)
+    {
+        return equality.Match(
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(SingleValueEquality equality)
+    {
+        return equality.Match(
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right))
+        );
+    }
+
+    private static IEnumerable<string> Entities(ArrayEquality equality)
+    {
+        return equality.Match(
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right))
+        );
+    }
+
+    private static IEnumerable<string> Entities(BooleanOperator op)
+    {
+        return op.Match(
+            and => and.Conditions.Match(
+                conditions => conditions.SelectMany(Entities),
+                array => Entities(array)
+            ),
+            or => or.Conditions.Match(
+                conditions => conditions.SelectMany(Entities),
+                array => Entities(array)
+            ),
+            not => Entities(not.Condition)
+        );
+    }
+
+    private static IEnumerable<string> Entities(Comparison comparison)
+    {
+        return comparison.Match(
+            c => Entities(c.Left).Concat(Entities(c.Right)),
+            c => Entities(c.Left).Concat(Entities(c.Right)),
+            c => Entities(c.Left).Concat(Entities(c.Right)),
+            c => Entities(c.Left).Concat(Entities(c.Right)),
+            c => Entities(c.Left).Concat(Entities(c.Right))
+        );
+    }
+
+    // ===== Array returnings =====
+
+    private static IEnumerable<string> Entities(ArrayReturning returning)
+    {
+        return returning.Match(
+            Entities,
+            Entities,
+            Entities,
+            Entities,
+            Entities,
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(BooleanArrayReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            field => One(field.Entity),
+            _ => None,
+            Entities,
+            Entities,
+            and => and.Conditions.SelectMany(Entities),
+            or => or.Conditions.SelectMany(Entities),
+            not => Entities(not.Condition)
+        );
+    }
+
+    private static IEnumerable<string> Entities(DateArrayReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            field => One(field.Entity),
+            _ => None,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(DateTimeArrayReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            field => One(field.Entity),
+            _ => None,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(NumberArrayReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            field => One(field.Entity),
+            _ => None,
+            Entities,
+            Entities,
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(StringArrayReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            field => One(field.Entity),
+            _ => None
+        );
+    }
+
+    private static IEnumerable<string> Entities(TimeArrayReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            field => One(field.Entity),
+            _ => None,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(UuidArrayReturning returning)
+    {
+        return returning.Match(
+            _ => None,
+            field => One(field.Entity),
+            _ => None
+        );
+    }
+
+    // ===== Per-row composites =====
+
+    private static IEnumerable<string> Entities(EachComparison comparison)
+    {
+        return comparison.Match(
+            c => Entities(c.Left).Concat(Entities(c.Right)),
+            c => Entities(c.Left).Concat(Entities(c.Right)),
+            c => Entities(c.Left).Concat(Entities(c.Right)),
+            c => Entities(c.Left).Concat(Entities(c.Right)),
+            c => Entities(c.Left).Concat(Entities(c.Right))
+        );
+    }
+
+    private static IEnumerable<string> Entities(EachEquality equality)
+    {
+        return equality.Match(
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right)),
+            eq => Entities(eq.Left).Concat(Entities(eq.Right))
+        );
+    }
+
+    private static IEnumerable<string> Entities(EachArithmetic arithmetic)
+    {
+        return arithmetic.Match(
+            add => add.Values.SelectMany(Entities),
+            subtract => subtract.Values.SelectMany(Entities),
+            multiply => multiply.Values.SelectMany(Entities),
+            divide => divide.Values.SelectMany(Entities)
+        );
+    }
+
+    private static IEnumerable<string> Entities(EachDateAddDays op)
+    {
+        return Entities(op.Left).Concat(Entities(op.Right));
+    }
+
+    private static IEnumerable<string> Entities(EachDateDiffDays op)
+    {
+        return Entities(op.Left).Concat(Entities(op.Right));
+    }
+
+    private static IEnumerable<string> Entities(EachTimeAddSeconds op)
+    {
+        return Entities(op.Left).Concat(Entities(op.Right));
+    }
+
+    private static IEnumerable<string> Entities(EachTimeDiffSeconds op)
+    {
+        return Entities(op.Left).Concat(Entities(op.Right));
+    }
+
+    private static IEnumerable<string> Entities(EachDateTimeAddSeconds op)
+    {
+        return Entities(op.Left).Concat(Entities(op.Right));
+    }
+
+    private static IEnumerable<string> Entities(EachDateTimeDiffSeconds op)
+    {
+        return Entities(op.Left).Concat(Entities(op.Right));
+    }
+
+    // ===== Broadcast operands (single value | per-row array) =====
+
+    private static IEnumerable<string> Entities(
+        OneOf<BooleanReturning, BooleanArrayReturning> value
+    )
+    {
+        return value.Match(
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(
+        OneOf<NumberReturning, NumberArrayReturning> value
+    )
+    {
+        return value.Match(
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(
+        OneOf<StringReturning, StringArrayReturning> value
+    )
+    {
+        return value.Match(
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(
+        OneOf<DateReturning, DateArrayReturning> value
+    )
+    {
+        return value.Match(
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(
+        OneOf<TimeReturning, TimeArrayReturning> value
+    )
+    {
+        return value.Match(
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(
+        OneOf<DateTimeReturning, DateTimeArrayReturning> value
+    )
+    {
+        return value.Match(
+            Entities,
+            Entities
+        );
+    }
+
+    private static IEnumerable<string> Entities(
+        OneOf<UuidReturning, UuidArrayReturning> value
+    )
+    {
+        return value.Match(
+            Entities,
+            Entities
+        );
+    }
+}

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/JoinApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/JoinApplicator.cs
@@ -32,7 +32,8 @@ internal static class JoinApplicator
         string schemaName = reversedPath.Skip(1).First();
 
         KeyValuePair<ITable, IStoredTableDataSet> rightDataset = datasets
-            .First(x => x.Schema.Name.TextValue == schemaName)
+            .Where(x => x.Schema.Name.TextValue == schemaName)
+            .SelectMany(x => x)
             .First(x => x.Key.Name.TextValue == tableName);
 
         List<IColumn> rightColumns =

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
@@ -39,6 +39,8 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
         Query query
     )
     {
+        EntityReferenceValidator.Validate(query);
+
         List<IStoredSchemaDataSet> datasetList = [.. datasets];
 
         IEnumerable<string> reversedPath = query
@@ -50,7 +52,8 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
         string schemaName = reversedPath.Skip(1).First();
 
         IStoredTableDataSet targetTableDataset = datasetList
-            .First(x => x.Schema.Name.TextValue == schemaName)
+            .Where(x => x.Schema.Name.TextValue == schemaName)
+            .SelectMany(x => x)
             .First(x => x.Key.Name.TextValue == tableName)
             .Value;
 
@@ -89,8 +92,11 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
             queryable = OrderByApplicator.Apply(queryable, query.OrderBy);
         }
 
+        // HAVING with no groupBy still filters the implicit whole-set group,
+        // so it engages group mode on its own.
         bool groupMode =
             query.GroupBy is not null
+            || query.Having is not null
             || query.SelectExpressions.Any(expression =>
                 expression.TryPickT0(out SingleValueReturning singleValue, out _)
                 && AggregateEvaluator.IsAggregate(singleValue)
@@ -112,8 +118,14 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
 
         if (query.Pagination is not null)
         {
-            queryable = queryable.Skip((int)query.Pagination.Skip);
-            queryable = queryable.Take((int)query.Pagination.Take);
+            // Skip/take are Int64 on the wire; clamp instead of letting the
+            // narrowing cast wrap into negative (no-op / empty) LINQ calls.
+            queryable = queryable.Skip(
+                (int)Math.Clamp(query.Pagination.Skip, 0, int.MaxValue)
+            );
+            queryable = queryable.Take(
+                (int)Math.Clamp(query.Pagination.Take, 0, int.MaxValue)
+            );
         }
 
         return queryable;

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Api/DuplicateSchemaNameTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Api/DuplicateSchemaNameTests.cs
@@ -14,8 +14,6 @@ using String = Pure.Primitives.String.String;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Api;
 
-#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
-
 // PureQLProjection accepts an open IEnumerable<IStoredSchemaDataSet>, and
 // nothing forbids two datasets from sharing a schema name (a host that
 // concatenates datasets from several sources produces exactly this shape).
@@ -69,13 +67,7 @@ public sealed class DuplicateSchemaNameTests
         return new StoredSchemaDataset(schema, datasetsByTable);
     }
 
-    [Fact(
-        Skip = "Issue #84: entity resolution consults only the first schema "
-            + "dataset with a matching name, so a from table that lives in a "
-            + "later same-named dataset throws InvalidOperationException "
-            + "instead of resolving."
-    )]
-    [Trait("Status", "KnownGap")]
+    [Fact]
     public void FromTableInALaterSameNamedSchemaDatasetResolves()
     {
         IStoredSchemaDataSet first = SingleTableDataset(
@@ -110,13 +102,7 @@ public sealed class DuplicateSchemaNameTests
         Assert.Equal(BetaValue, result.Row(0)["beta_name"]);
     }
 
-    [Fact(
-        Skip = "Issue #84: join resolution consults only the first schema "
-            + "dataset with a matching name, so a join table that lives in a "
-            + "later same-named dataset throws InvalidOperationException "
-            + "instead of resolving."
-    )]
-    [Trait("Status", "KnownGap")]
+    [Fact]
     public void JoinTableInALaterSameNamedSchemaDatasetResolves()
     {
         IStoredSchemaDataSet first = SingleTableDataset(

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/HavingWithoutGroupByTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/HavingWithoutGroupByTests.cs
@@ -9,8 +9,6 @@ using PureQL.CSharp.Model.Scalars;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.GroupBy;
 
-#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
-
 // HAVING with no groupBy is schema-valid (SQL-style implicit whole-set
 // group). It is honoured today only when the select list contains an
 // aggregate (which engages group mode); with plain field selects the clause
@@ -67,12 +65,7 @@ public sealed class HavingWithoutGroupByTests
         );
     }
 
-    [Fact(
-        Skip = "Issue #83: with no groupBy and no aggregate select the query "
-            + "never enters group mode, so HAVING is silently dropped and a "
-            + "constant-false condition still returns every row."
-    )]
-    [Trait("Status", "KnownGap")]
+    [Fact]
     public void HavingWithoutGroupByFiltersTheImplicitWholeSetGroup()
     {
         SampleDatabase db = new SampleDatabase();

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/UndeclaredAliasEntityTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/UndeclaredAliasEntityTests.cs
@@ -6,8 +6,6 @@ using PureQL.CSharp.Model.Fields;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
 
-#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
-
 // The spec gives joinItem no alias: joined tables must be referenced by
 // their full "schema.table" entity string, and only the root from supports
 // an alias. A field reference whose entity matches neither the from
@@ -44,13 +42,7 @@ public sealed class UndeclaredAliasEntityTests
         );
     }
 
-    [Fact(
-        Skip = "Issue #82: a join-on field reference via an undeclared join "
-            + "alias silently binds to the base table's same-named column, "
-            + "so the equi-join key never matches and the join returns an "
-            + "empty result instead of failing fast."
-    )]
-    [Trait("Status", "KnownGap")]
+    [Fact]
     public void JoinOnConditionViaUndeclaredAliasFailsFast()
     {
         CollidingNameDatabase db = new CollidingNameDatabase();
@@ -105,12 +97,7 @@ public sealed class UndeclaredAliasEntityTests
         ));
     }
 
-    [Fact(
-        Skip = "Issue #82: selecting a colliding column via an undeclared "
-            + "join alias silently returns the base table's values instead "
-            + "of failing fast."
-    )]
-    [Trait("Status", "KnownGap")]
+    [Fact]
     public void SelectOfCollidingColumnViaUndeclaredAliasFailsFast()
     {
         CollidingNameDatabase db = new CollidingNameDatabase();

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Pagination/PaginationRangeTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Pagination/PaginationRangeTests.cs
@@ -6,8 +6,6 @@ using ModelPagination = PureQL.CSharp.Model.Pagination;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Pagination;
 
-#pragma warning disable xUnit1004 // skipped: reproduces a known translator bug
-
 // Pagination carries skip/take as Int64, but they are applied through an
 // unchecked cast to Int32, so values beyond int.MaxValue wrap and silently
 // produce the wrong window (issue #85).
@@ -40,12 +38,7 @@ public sealed class PaginationRangeTests
         );
     }
 
-    [Fact(
-        Skip = "Issue #85: take = long.MaxValue wraps to -1 through the "
-            + "unchecked int cast, so a query asking for everything returns "
-            + "an empty result."
-    )]
-    [Trait("Status", "KnownGap")]
+    [Fact]
     public void TakeBeyondIntMaxReturnsEveryRow()
     {
         SampleDatabase db = new SampleDatabase();
@@ -60,12 +53,7 @@ public sealed class PaginationRangeTests
         Assert.Equal(db.UserRows.Count, result.Count);
     }
 
-    [Fact(
-        Skip = "Issue #85: skip = long.MaxValue wraps to -1 through the "
-            + "unchecked int cast, making the skip a no-op, so rows that "
-            + "should all be skipped are returned."
-    )]
-    [Trait("Status", "KnownGap")]
+    [Fact]
     public void SkipBeyondIntMaxReturnsNoRows()
     {
         SampleDatabase db = new SampleDatabase();


### PR DESCRIPTION
## Summary

Fixes the four translator bugs pinned by the skipped reproduction tests from #86. All seven `KnownGap` tests are unskipped and pass; the suite is green with **zero skips** (202/202).

Fixes #82, fixes #83, fixes #84, fixes #85.

## Changes

### #82 — fail fast on unresolvable field-reference entities

New internal `EntityReferenceValidator`, invoked at the top of `RowsFromDatasets.Build`. It walks every field reference in the query — select expressions, WHERE, each join's ON, groupBy fields, HAVING, orderBy, including aggregate arguments, per-row arithmetic operands, broadcast operands and boolean composites — and throws `NotSupportedException` when a reference's entity matches neither the `from` entity, the `from` alias, nor any join's entity.

Previously such references (an undeclared join alias like `"sp"`, or a typo — the spec gives `joinItem` no alias, and the wire converter silently drops the property) degraded to bare-name resolution and bound to the wrong column: an aliased join-on key compared the base table's own FK against its own PK and matched nothing, and an aliased select of a colliding column name silently returned the base table's values. The error message states the offending entity and points at the full `schema.table` requirement.

Spec-legal `from`-alias references are unaffected (the alias is part of the known set) and remain covered by the passing tests in `UndeclaredAliasEntityTests`.

### #83 — HAVING without GROUP BY

`query.Having is not null` now engages group mode on its own, so the condition filters the implicit whole-set group (SPEC-REVIEW T18 reading) instead of being silently dropped when the select list has no aggregate.

### #84 — entity resolution across same-named schema datasets

`RowsFromDatasets.Build` and `JoinApplicator.Apply` now resolve `schema.table` with `.Where(schema name match).SelectMany(...)` instead of `.First(schema name match)`, so a table living in a *later* dataset with the same schema name (hosts that concatenate datasets from several sources/adapters) resolves instead of throwing `InvalidOperationException`.

### #85 — pagination overflow

`skip`/`take` are clamped to `[0, int.MaxValue]` before the `Skip`/`Take` calls, so `Int64` values beyond `int.MaxValue` no longer wrap into negative arguments (`take = long.MaxValue` returned an empty result; oversized `skip` was a no-op).

## Verification

- `dotnet build --no-restore -warnaserror` — clean
- `dotnet format --verify-no-changes` — clean
- `dotnet test` — **202 passed, 0 skipped, 0 failed** (the 7 previously skipped reproductions now pass)
- No public API changes (all touched/added types are internal); package validation unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)