### PR TITLE
Project scalar select expressions as constant cells

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,8 @@ All translation work is done by internal classes:
 - **`QualifiedColumn`** — an `IColumn` wrapper carrying the "schema.table" entity a joined column came from; deliberately a class (not a record) because the wrapped column types' `Equals`/`GetHashCode` throw by design
 - **`WhereExpressionBuilder`** — compiles a `BooleanReturning` *or* per-row `BooleanArrayReturning` AST node from `PureQL.CSharp.Model` into a `Func<IRow, bool>` LINQ predicate (entry point: `BuildPredicate(OneOf<BooleanReturning, BooleanArrayReturning>)`). Implements the per-row `each*` family — `EachEquality`, `EachComparison`, `EachAnd`/`EachOr`/`EachNot`, plus per-row arithmetic (`EachArithmetic`, `EachDateAddDays`/`EachDateDiffDays`, `EachTimeAddSeconds`/`EachTimeDiffSeconds`, `EachDateTimeAddSeconds`/`EachDateTimeDiffSeconds`)
 - **`OrderByApplicator`** — applies `IEnumerable<OrderByItem>` ordering, honouring per-item `SortDirection` (`Asc`/`Desc`)
-- **`GroupByApplicator`** — groups rows by the GROUP BY fields (or the whole set when only aggregates are selected), filters groups with HAVING, and emits one projected row per group (aggregate select expressions fold the group; field select expressions take the group key value)
+- **`GroupByApplicator`** — groups rows by the GROUP BY fields (or the whole set when only aggregates are selected), filters groups with HAVING, and emits one projected row per group (aggregate select expressions fold the group; field select expressions take the group key value; scalar select expressions repeat their constant)
+- **`ScalarCell`** — builds the constant output cell of a scalar select expression (`SELECT 5 AS version`), repeated on every output row in both the per-row and group projection paths; text formatted via `ValueText` so it round-trips through `CellValueExtractor`
 - **`AggregateEvaluator`** — evaluates single-value expressions over a group of rows: `Count`, `NumberAggregate` (sum/min/max/avg), `StringAggregate` (min/max, ordinal), `Date`/`DateTime`/`TimeAggregate` (min/max), plus HAVING boolean composites (equality/comparison/and/or/not over constants and aggregates)
 - **`DistinctApplicator`** — deduplicates the *projected* row set when `Query.Distinct == true` (SQL `SELECT DISTINCT` semantics)
 - **`CellValueExtractor`** — resolves a field reference (entity + field name) against a row and extracts typed .NET values from `ICell` for the seven supported column types: bool, date, datetime, double, string, time, uuid. Resolution prefers a `QualifiedColumn` matching the reference's entity, then the base table's (untagged) same-named column, then any same-named column
@@ -53,7 +54,7 @@ The library is **not AOT-compatible** (`IsAotCompatible = false`) because the qu
 
 **CI thresholds:** code coverage warning at 99%, failure below 52%; mutation score failure below 32%.
 
-**Known execution gaps:** parameter binding (no public binding API), computed/scalar `select` columns, single-value `Arithmetic`, temporal `Average` aggregates (undefined rounding semantics), and aggregates inside WHERE are not implemented. These constructs raise `NotSupportedException` rather than silently producing wrong results.
+**Known execution gaps:** parameter binding (no public binding API), computed `select` columns, single-value `Arithmetic`, temporal `Average` aggregates (undefined rounding semantics), and aggregates inside WHERE are not implemented. These constructs raise `NotSupportedException` rather than silently producing wrong results.
 
 ## Code Style
 

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/GroupByApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/GroupByApplicator.cs
@@ -63,11 +63,19 @@ internal static class GroupByApplicator
             )
         )
         {
+            if (ScalarCell.IsScalar(singleValue))
+            {
+                ICell constant = ScalarCell.From(singleValue);
+
+                return new ProjectionItem(column, _ => constant);
+            }
+
             if (!AggregateEvaluator.IsAggregate(singleValue))
             {
                 throw new NotSupportedException(
-                    "SingleValueReturning (scalar/parameter) cannot be projected "
-                        + "as a column field."
+                    "Only scalar and aggregate SingleValueReturning expressions "
+                        + "can be projected per group; parameters and "
+                        + "single-value composites are not supported."
                 );
             }
 

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
@@ -144,11 +144,7 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
                     new Collections.Generic.Dictionary<ProjectionItem, IColumn, ICell>(
                         plan,
                         item => item.Column,
-                        item => CellValueExtractor.GetRequiredCell(
-                            row,
-                            item.FieldEntity,
-                            item.FieldName
-                        ),
+                        item => item.Cell(row),
                         column => new ColumnHash(column)
                     )
                 )
@@ -157,21 +153,40 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
 
     private static ProjectionItem ProjectionItemOf(SelectExpression expression)
     {
-        return expression.TryPickT0(out SingleValueReturning _, out ArrayReturning array)
-            ? throw new NotSupportedException(
-                "SingleValueReturning (scalar/parameter) cannot be projected "
-                    + "as a column field."
+        IColumn column = SelectColumns.OutputColumn(expression);
+
+        if (
+            expression.TryPickT0(
+                out SingleValueReturning singleValue,
+                out ArrayReturning array
             )
-            : new ProjectionItem(
-                SelectColumns.OutputColumn(expression),
-                SelectColumns.FieldEntity(array),
-                SelectColumns.FieldName(array)
-            );
+        )
+        {
+            if (!ScalarCell.IsScalar(singleValue))
+            {
+                throw new NotSupportedException(
+                    "Only scalar SingleValueReturning expressions can be "
+                        + "projected per row; parameters and single-value "
+                        + "composites are not supported."
+                );
+            }
+
+            ICell cell = ScalarCell.From(singleValue);
+
+            return new ProjectionItem(column, _ => cell);
+        }
+
+        string fieldEntity = SelectColumns.FieldEntity(array);
+        string fieldName = SelectColumns.FieldName(array);
+
+        return new ProjectionItem(
+            column,
+            row => CellValueExtractor.GetRequiredCell(row, fieldEntity, fieldName)
+        );
     }
 
     private sealed record ProjectionItem(
         IColumn Column,
-        string FieldEntity,
-        string FieldName
+        Func<IRow, ICell> Cell
     );
 }

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/ScalarCell.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/ScalarCell.cs
@@ -1,0 +1,43 @@
+using Pure.RelationalSchema.Storage.Abstractions;
+using PureQL.CSharp.Model.Returnings;
+using String = Pure.Primitives.String.String;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection;
+
+// Builds the constant output cell of a scalar select expression
+// (SELECT 5 AS version): standard SQL repeats the constant on every output
+// row. The cell text is the canonical invariant form that CellValueExtractor
+// round-trips, so scalar cells behave exactly like stored ones.
+internal static class ScalarCell
+{
+    internal static bool IsScalar(SingleValueReturning returning)
+    {
+        return returning.Match(
+            boolean => boolean.IsT1,
+            date => date.IsT1,
+            dateTime => dateTime.IsT1,
+            number => number.IsT1,
+            text => text.IsT1,
+            time => time.IsT1,
+            uuid => uuid.IsT1
+        );
+    }
+
+    internal static ICell From(SingleValueReturning returning)
+    {
+        return new Cell(new String(Text(returning)));
+    }
+
+    private static string Text(SingleValueReturning returning)
+    {
+        return returning.Match(
+            boolean => ValueText.From(boolean.AsT1.Value),
+            date => ValueText.From(date.AsT1.Value),
+            dateTime => ValueText.From(dateTime.AsT1.Value),
+            number => ValueText.From(number.AsT1.Value),
+            text => text.AsT1.Value,
+            time => ValueText.From(time.AsT1.Value),
+            uuid => ValueText.From(uuid.AsT1.Value)
+        );
+    }
+}

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/ValueText.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/ValueText.cs
@@ -6,9 +6,19 @@ namespace Pure.RelationalSchema.Storage.PureQL.Projection;
 // CellValueExtractor, so computed cells round-trip like stored ones.
 internal static class ValueText
 {
+    internal static string From(bool value)
+    {
+        return value ? bool.TrueString : bool.FalseString;
+    }
+
     internal static string From(double value)
     {
         return value.ToString(CultureInfo.InvariantCulture);
+    }
+
+    internal static string From(Guid value)
+    {
+        return value.ToString("D");
     }
 
     internal static string From(DateOnly value)

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/ScalarWithAggregateTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/ScalarWithAggregateTests.cs
@@ -1,0 +1,344 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.GroupBy;
+
+// Scalar select expressions are legal alongside aggregates in group mode
+// (SELECT 'all' AS scope, COUNT(id) FROM t): the constant repeats on every
+// group's output row, for whole-set groups, per-key groups and groups
+// surviving HAVING alike.
+[Trait("Clause", "GroupBy")]
+[Trait("Feature", "ScalarWithAggregate")]
+public sealed class ScalarWithAggregateTests
+{
+    [Fact]
+    public void ScalarAlongsideWholeSetCountProjectsSingleRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(new StringScalar("all"))
+                    ),
+                    "scope"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "order_count"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal("all", result.Row(0)["scope"]);
+        Assert.Equal(db.OrderRows.Count, result.Row(0).Double("order_count"));
+    }
+
+    [Fact]
+    public void ScalarRepeatsOnEveryGroupRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(new NumberScalar(1))
+                    ),
+                    "version"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "status_total"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new StringField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.Status
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<string, double> expectedTotals = db.OrderRows
+            .GroupBy(order => order.OrderStatus)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Sum(order => order.OrderTotal)
+            );
+
+        Assert.Equal(expectedTotals.Count, result.Count);
+        Assert.All(result.Rows, row => Assert.Equal(1, row.Double("version")));
+        Assert.Equal(
+            expectedTotals.Values.OrderBy(total => total),
+            result.Rows
+                .Select(row => row.Double("status_total") ?? double.NaN)
+                .OrderBy(total => total)
+        );
+    }
+
+    [Fact]
+    public void ScalarGroupKeyFieldAndAggregateMixInOneQuery()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(new StringScalar("2024-06"))
+                    ),
+                    "period"
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "status_total"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new StringField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.Status
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<string, double> expectedTotals = db.OrderRows
+            .GroupBy(order => order.OrderStatus)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Sum(order => order.OrderTotal)
+            );
+
+        Assert.Equal(expectedTotals.Count, result.Count);
+        Assert.All(
+            result.Rows,
+            row =>
+            {
+                Assert.Equal("2024-06", row["period"]);
+                string status = row[SampleDatabase.Orders.Status] ?? string.Empty;
+                Assert.Equal(
+                    expectedTotals[status],
+                    row.Double("status_total")
+                );
+            }
+        );
+    }
+
+    [Fact]
+    public void BooleanAndUuidScalarsProjectInGroupMode()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Guid marker = new Guid("9b2b1f6e-3c86-4c50-8f6a-2f6d1a8f2c11");
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new BooleanReturning(new BooleanScalar(true))
+                    ),
+                    "flag"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new UuidReturning(new UuidScalar(marker))
+                    ),
+                    "marker"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "order_count"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(true, result.Row(0).Bool("flag"));
+        Assert.Equal(marker, result.Row(0).Uuid("marker"));
+        Assert.Equal(db.OrderRows.Count, result.Row(0).Double("order_count"));
+    }
+
+    [Fact]
+    public void ScalarProjectsOnGroupsSurvivingHaving()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(new StringScalar("repeat-buyer"))
+                    ),
+                    "tag"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "order_count"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.GreaterThan,
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(1))
+                    )
+                )
+            ),
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedGroups = db.OrderRows
+            .GroupBy(order => order.OrderUserId)
+            .Count(group => group.Count() > 1);
+
+        Assert.Equal(expectedGroups, result.Count);
+        Assert.All(result.Rows, row => Assert.Equal("repeat-buyer", row["tag"]));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/ScalarProjectionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/ScalarProjectionTests.cs
@@ -1,0 +1,402 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Select;
+
+// Scalar select expressions (SELECT 5 AS version FROM t) project a constant
+// cell repeated on every output row — standard SQL semantics. Covers all
+// seven scalar types, aliasing, mixing with field columns, and interaction
+// with WHERE, DISTINCT and pagination.
+[Trait("Clause", "Select")]
+[Trait("Feature", "ScalarProjection")]
+public sealed class ScalarProjectionTests
+{
+    [Fact]
+    public void NumberScalarProjectsConstantOnEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(new NumberScalar(5))
+                    ),
+                    "version"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.UserRows.Count, result.Count);
+        Assert.All(result.Rows, row => Assert.Equal(5, row.Double("version")));
+    }
+
+    [Fact]
+    public void AllSevenScalarTypesProjectTypedConstants()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Guid marker = new Guid("0f8fad5b-d9cb-469f-a165-70867728950e");
+        DateOnly release = new DateOnly(2024, 12, 31);
+        DateTime builtAt = new DateTime(2024, 12, 31, 23, 59, 58);
+        TimeOnly cutoff = new TimeOnly(17, 30, 15);
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new BooleanReturning(new BooleanScalar(true))
+                    ),
+                    "active"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new DateReturning(new DateScalar(release))
+                    ),
+                    "release"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new DateTimeReturning(new DateTimeScalar(builtAt))
+                    ),
+                    "built_at"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(new NumberScalar(42.5))
+                    ),
+                    "amount"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(new StringScalar("v2"))
+                    ),
+                    "label"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new TimeReturning(new TimeScalar(cutoff))
+                    ),
+                    "cutoff"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new UuidReturning(new UuidScalar(marker))
+                    ),
+                    "marker"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.UserRows.Count, result.Count);
+        Assert.All(
+            result.Rows,
+            row =>
+            {
+                Assert.Equal(true, row.Bool("active"));
+                Assert.Equal(release, row.Date("release"));
+                Assert.Equal(builtAt, row.DateTime("built_at"));
+                Assert.Equal(42.5, row.Double("amount"));
+                Assert.Equal("v2", row["label"]);
+                Assert.Equal(cutoff, row.Time("cutoff"));
+                Assert.Equal(marker, row.Uuid("marker"));
+            }
+        );
+    }
+
+    [Fact]
+    public void ScalarAlongsideFieldColumnRepeatsPerRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(new StringScalar("v2"))
+                    ),
+                    "release"
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.UserRows.Count, result.Count);
+
+        for (int i = 0; i < db.UserRows.Count; i++)
+        {
+            Assert.Equal("v2", result.Row(i)["release"]);
+            Assert.Equal(
+                db.UserRows[i].UserName,
+                result.Row(i)[SampleDatabase.Users.Name]
+            );
+        }
+    }
+
+    [Fact]
+    public void ScalarWithoutAliasProjectsEmptyNamedColumn()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(new NumberScalar(7))
+                    )
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.UserRows.Count, result.Count);
+        Assert.Contains(string.Empty, result.ColumnNames);
+        Assert.All(result.Rows, row => Assert.Equal(7, row.Double(string.Empty)));
+    }
+
+    [Fact]
+    public void ScalarUnderWhereRepeatsOnlyOnFilteredRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(new StringScalar("active-user"))
+                    ),
+                    "tag"
+                ),
+            ],
+            new BooleanArrayReturning(
+                new BooleanField(
+                    SampleDatabase.Users.Entity,
+                    SampleDatabase.Users.Active
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.UserRows.Count(user => user.UserActive), result.Count);
+        Assert.All(result.Rows, row => Assert.Equal("active-user", row["tag"]));
+    }
+
+    [Fact]
+    public void DistinctCollapsesIdenticalScalarOnlyRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(new StringScalar("tag"))
+                    ),
+                    "tag"
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal("tag", result.Row(0)["tag"]);
+    }
+
+    [Fact]
+    public void ScalarWithPaginationProjectsConstantOnPagedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(new NumberScalar(9))
+                    ),
+                    "page_marker"
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            new global::PureQL.CSharp.Model.Pagination(1, 2)
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result.Rows, row => Assert.Equal(9, row.Double("page_marker")));
+    }
+
+    [Fact]
+    public void NegativeFractionalNumberScalarRoundTrips()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Products.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(new NumberScalar(-12.75))
+                    ),
+                    "adjustment"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.ProductRows.Count, result.Count);
+        Assert.All(result.Rows, row => Assert.Equal(-12.75, row.Double("adjustment")));
+    }
+
+    [Fact]
+    public void ScalarProjectsConstantOnEveryJoinedRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(new StringScalar("joined"))
+                    ),
+                    "source"
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                ),
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count, result.Count);
+        Assert.All(result.Rows, row => Assert.Equal("joined", row["source"]));
+    }
+
+    [Fact]
+    public void FalseBooleanScalarRoundTripsDistinctFromEmpty()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new BooleanReturning(new BooleanScalar(false))
+                    ),
+                    "flag"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.UserRows.Count, result.Count);
+        Assert.All(result.Rows, row => Assert.Equal(false, row.Bool("flag")));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/ScalarUnsupportedTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/ScalarUnsupportedTests.cs
@@ -1,0 +1,145 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Arithmetics;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Parameters;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Select;
+
+// Scalar constants are the only supported non-aggregate SingleValueReturning
+// select projections. Parameters (no binding API), single-value arithmetic
+// and boolean composites still have no defined result through this entry
+// point, so the translator fails fast with NotSupportedException instead of
+// silently producing wrong cells. These tests pin that explicit-failure
+// contract.
+[Trait("Clause", "Select")]
+[Trait("Feature", "ScalarProjection")]
+public sealed class ScalarUnsupportedTests
+{
+    [Fact]
+    public void NumberParameterInSelectFailsFastWithoutBinding()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(new NumberParameter("limit"))
+                    ),
+                    "limit"
+                ),
+            ]
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() =>
+            new PureQLProjection(db.Datasets, query)
+        );
+    }
+
+    [Fact]
+    public void SingleValueArithmeticInSelectFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Arithmetic(
+                                new Add(
+                                    [
+                                        new NumberReturning(new NumberScalar(1)),
+                                        new NumberReturning(new NumberScalar(2)),
+                                    ]
+                                )
+                            )
+                        )
+                    ),
+                    "sum"
+                ),
+            ]
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() =>
+            new PureQLProjection(db.Datasets, query)
+        );
+    }
+
+    [Fact]
+    public void BooleanCompositeInSelectFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new BooleanReturning(
+                            new Comparison(
+                                new NumberComparison(
+                                    ComparisonOperator.GreaterThan,
+                                    new NumberReturning(new NumberScalar(2)),
+                                    new NumberReturning(new NumberScalar(1))
+                                )
+                            )
+                        )
+                    ),
+                    "flag"
+                ),
+            ]
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() =>
+            new PureQLProjection(db.Datasets, query)
+        );
+    }
+
+    [Fact]
+    public void ParameterAlongsideAggregateFailsFastInGroupMode()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(new StringParameter("scope"))
+                    ),
+                    "scope"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "order_count"
+                ),
+            ]
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() =>
+            new PureQLProjection(db.Datasets, query)
+        );
+    }
+}


### PR DESCRIPTION
Closes #62.

## Problem

`SELECT 5 AS version, TRUE AS active FROM schema.table` threw `NotSupportedException` ("SingleValueReturning (scalar/parameter) cannot be projected as a column field") because `RowsFromDatasets.ProjectionItemOf` unconditionally rejected every non-field select expression.

## Solution

Scalar `SingleValueReturning` expressions now project as a constant cell repeated on every output row — standard SQL semantics — in both projection paths:

- **`ScalarCell`** (new): `IsScalar` detects the scalar variant of the seven typed returnings (bool, date, datetime, number, string, time, uuid); `From` builds the constant `ICell` with canonical invariant text that `CellValueExtractor` round-trips.
- **`ValueText`**: adds `From(bool)` and `From(Guid)`.
- **`RowsFromDatasets`**: each projection item is now an `(IColumn, Func<IRow, ICell>)` pair — field references read the row's cell, scalars return a pre-computed constant.
- **`GroupByApplicator`**: scalars are legal alongside aggregates and group-key fields (`SELECT 'all' AS scope, COUNT(id) FROM t`), including boolean and uuid scalars, which the aggregate text path could not express.

Parameters (Gap 1), single-value `Arithmetic` and boolean composites in SELECT still fail fast with `NotSupportedException`, with messages reflecting the narrower gap.

## Tests (19 new, 221 total, all passing)

- `Select/ScalarProjectionTests` — all seven scalar types round-trip typed constants; scalar alongside a field column; missing alias yields an empty-named column; WHERE, DISTINCT (identical scalar-only rows collapse to one), pagination, INNER JOIN; negative fractional numbers; `false` distinct from empty cell.
- `GroupBy/ScalarWithAggregateTests` — scalar + whole-set COUNT, scalar repeated per group with SUM, scalar + group-key field + aggregate in one query, boolean/uuid scalars in group mode, scalar on groups surviving HAVING.
- `Select/ScalarUnsupportedTests` — pins the fail-fast contract for parameters, single-value arithmetic, boolean composites, and a parameter alongside an aggregate in group mode.

No public API changes (all touched/added types are internal); package validation unaffected. CLAUDE.md's architecture and known-gaps notes updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)