### PR TITLE
Pin translator behaviour for live-reported join and comparison shapes

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinOnUuidLiteralTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinOnUuidLiteralTests.cs
@@ -1,0 +1,215 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+// A join whose ON condition compares a column to a uuid literal (the shape of
+// issue #92: ON orders.user_id = '0000...'). The each-equality must actually
+// gate the merged rows: a never-matching literal empties an inner join and
+// pads a left join, a matching literal keeps only the satisfying left rows
+// (crossed with every right row, since the condition does not constrain the
+// right side).
+[Trait("Clause", "Join")]
+[Trait("Feature", "JoinOnUuidLiteral")]
+public sealed class JoinOnUuidLiteralTests
+{
+    [Fact]
+    public void InnerJoinOnNeverMatchingUuidLiteralReturnsNoRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        )
+                    ),
+                    "hours"
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                ),
+                                new UuidReturning(new UuidScalar(Guid.Empty))
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    [Fact]
+    public void InnerJoinOnMatchingUuidLiteralKeepsOnlySatisfyingLeftRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Guid annId = db.UserRows[0].UserId;
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        )
+                    ),
+                    "hours"
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                ),
+                                new UuidReturning(new UuidScalar(annId))
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        // The condition constrains only the left side, so each satisfying
+        // order pairs with every user row.
+        int expected =
+            db.OrderRows.Count(order => order.OrderUserId == annId)
+            * db.UserRows.Count;
+
+        Assert.Equal(expected, result.Count);
+
+        double[] expectedTotals =
+        [
+            .. db.OrderRows
+                .Where(order => order.OrderUserId == annId)
+                .Select(order => order.OrderTotal)
+                .OrderBy(total => total),
+        ];
+
+        Assert.Equal(
+            expectedTotals,
+            result.Rows
+                .Select(row => row.Double("hours") ?? double.NaN)
+                .Distinct()
+                .OrderBy(total => total)
+        );
+    }
+
+    [Fact]
+    public void LeftJoinOnNeverMatchingUuidLiteralPadsEveryLeftRowOnce()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        )
+                    ),
+                    "hours"
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    ),
+                    "customer"
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Left,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                ),
+                                new UuidReturning(new UuidScalar(Guid.Empty))
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count, result.Count);
+        Assert.All(result.Rows, row => Assert.Equal(string.Empty, row["customer"]));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/EachComparisonTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/EachComparisonTests.cs
@@ -63,6 +63,56 @@ public sealed class EachComparisonTests
     }
 
     [Fact]
+    public void EachNumberGreaterThanZeroKeepsEveryPositiveRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        )
+                    ),
+                    "hours"
+                ),
+            ],
+            new BooleanArrayReturning(
+                new EachComparison(
+                    new EachNumberComparison(
+                        EachComparisonOperator.EachGreaterThan,
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(0))
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        // Every sample total is positive, so nothing may be filtered out
+        // (issue #90's live symptom was zero rows for exactly this shape).
+        Assert.Equal(db.OrderRows.Count, result.Count);
+    }
+
+    [Fact]
     public void EachNumberGreaterThanOrEqualIncludesThreshold()
     {
         SampleDatabase db = new SampleDatabase();


### PR DESCRIPTION
## Context

Issues #90, #91, and #92 report query results that look like translator bugs (silent empty WHERE match, joined-column select rejected, join ON never filtering) observed live through the Concentrator API. Investigating each payload against this repo's translator directly (constructing the `Query` AST by hand, bypassing the wire) shows the translator evaluates all three shapes correctly:

- `#90`'s shape — a per-row numeric comparison (`eachGreaterThan`) against a scalar threshold — filters exactly as expected.
- `#91`/`#92`'s shape — an inner join whose `on` condition compares a field to a uuid literal — both selects the joined column and filters via `on` correctly.

The actual bug is in the wire layer: `PureQL.CSharp.Model.Serialization`'s `QueryConverter` bound the join list from JSON property `join` instead of the spec-mandated `joins`, so `Query.Join` silently arrived `null` for every spec-compliant request — an inner join became a no-op (#92) and `EntityReferenceValidator` (which derives its known-entity set from `Query.Join`) rejected any select of the joined table (#91), because as far as the translator could see, no join had been declared at all. Fixed in kudima03/PureQL.CSharp.Model.Serialization#49.

`#90`'s live 0-rows symptom used a `greaterThan`-with-field-operand shape that is not spec-valid at the current serialization version (per-row operators are `eachGreaterThan` etc.); that payload now fails loudly with a 400 rather than silently matching nothing, so it doesn't reproduce against current `main`. The spec-correct equivalent is covered here.

## Changes (tests only — no translator source changes needed)

- `Joins/JoinOnUuidLiteralTests` — an inner join whose `on` condition equates a field to a uuid literal: a never-matching literal empties the result, a matching literal keeps only the satisfying left-side rows (crossed with every right row, since the condition doesn't constrain the right side); a left-join variant confirms unmatched rows are padded rather than dropped. This is the exact shape reported in #92.
- `Where/Each/EachComparisonTests.EachNumberGreaterThanZeroKeepsEveryPositiveRow` — `eachGreaterThan` against a `0` threshold over an all-positive column keeps every row, pinning #90's spec-correct shape.
- #91's shape (select of a joined column) was already covered by the existing `Joins/JoinedTableColumnProjectionTests` and `Joins/InnerJoinTests` suites; no new test was needed there, just confirmation it passes.

4 new tests, 225 total, all passing; `dotnet format --verify-no-changes` is clean.

## Related

- kudima03/PureQL.CSharp.Model.Serialization#49 is the actual fix (wire property `join` → `joins`)
- Closes #90
- Closes #91
- Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)