### PR TITLE
Test suite: aggregate/HAVING/DISTINCT/alias interaction coverage

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/ComputedAggregateTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/ComputedAggregateTests.cs
@@ -1,0 +1,467 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachArithmetics;
+using PureQL.CSharp.Model.EachDateArithmetics;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.EachTimeArithmetics;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Aggregates;
+
+// An aggregate's argument may be any array-returning expression, including
+// per-row (each*) computed values: sum/average/count fold the computed
+// per-row results, and min/max fold per-row temporal diffs, not stored
+// columns directly.
+[Trait("Clause", "Aggregate")]
+[Trait("Feature", "ComputedAggregate")]
+public sealed class ComputedAggregateTests
+{
+    private static Join ItemsToProductsJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Products.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.ProductId
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Products.Entity,
+                                SampleDatabase.Products.Id
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static Join UsersToOrdersJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Orders.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static NumberArrayReturning QtyTimesPrice()
+    {
+        return new NumberArrayReturning(
+            new EachArithmetic(
+                new EachMultiply(
+                    [
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.Qty
+                            )
+                        ),
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Products.Entity,
+                                SampleDatabase.Products.Price
+                            )
+                        ),
+                    ]
+                )
+            )
+        );
+    }
+
+    private static double PriceOf(SampleDatabase db, Guid productId)
+    {
+        return db.ProductRows
+            .Single(product => product.ProductId == productId)
+            .ProductPrice;
+    }
+
+    [Fact]
+    public void SumOfEachMultiplyProjectsPerGroupRevenue()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.OrderItems.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.OrderId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(new SumNumber(QtyTimesPrice()))
+                        )
+                    ),
+                    "revenue"
+                ),
+            ],
+            where: null,
+            [ItemsToProductsJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.OrderItems.Entity,
+                        SampleDatabase.OrderItems.OrderId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = db.OrderItemRows
+            .GroupBy(item => item.ItemOrderId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Sum(item => item.ItemQty * PriceOf(db, item.ItemProductId))
+            );
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.OrderItems.OrderId)!.Value,
+            row => row.Double("revenue")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void AverageOfEachMultiplyProjectsPerGroupMean()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.OrderItems.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.OrderId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(new AverageNumber(QtyTimesPrice()))
+                        )
+                    ),
+                    "meanLineValue"
+                ),
+            ],
+            where: null,
+            [ItemsToProductsJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.OrderItems.Entity,
+                        SampleDatabase.OrderItems.OrderId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = db.OrderItemRows
+            .GroupBy(item => item.ItemOrderId)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Average(item =>
+                    item.ItemQty * PriceOf(db, item.ItemProductId)
+                )
+            );
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.OrderItems.OrderId)!.Value,
+            row => row.Double("meanLineValue")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MaxOfEachDateDiffDaysProjectsPerGroupSpan()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new MaxNumber(
+                                    new NumberArrayReturning(
+                                        new EachDateDiffDays(
+                                            new DateArrayReturning(
+                                                new DateField(
+                                                    SampleDatabase.Orders.Entity,
+                                                    SampleDatabase.Orders.PlacedOn
+                                                )
+                                            ),
+                                            new DateArrayReturning(
+                                                new DateField(
+                                                    SampleDatabase.Users.Entity,
+                                                    SampleDatabase.Users.SignupDate
+                                                )
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "maxSpanDays"
+                ),
+            ],
+            where: null,
+            [UsersToOrdersJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Users.Entity,
+                        SampleDatabase.Users.Id
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = db.OrderRows
+            .Join(
+                db.UserRows,
+                order => order.OrderUserId,
+                user => user.UserId,
+                (order, user) => (user.UserId, Span: (double)(order.PlacedOn.DayNumber - user.SignupDate.DayNumber))
+            )
+            .GroupBy(pair => pair.UserId)
+            .ToDictionary(group => group.Key, group => group.Max(pair => pair.Span));
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Users.Id)!.Value,
+            row => row.Double("maxSpanDays")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MinOfEachTimeDiffSecondsProjectsPerGroupValue()
+    {
+        SampleDatabase db = new SampleDatabase();
+        TimeOnly origin = new TimeOnly(8, 0, 0);
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new BooleanArrayReturning(
+                            new BooleanField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Active
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new MinNumber(
+                                    new NumberArrayReturning(
+                                        new EachTimeDiffSeconds(
+                                            new TimeArrayReturning(
+                                                new TimeField(
+                                                    SampleDatabase.Users.Entity,
+                                                    SampleDatabase.Users.ShiftStart
+                                                )
+                                            ),
+                                            new TimeReturning(new TimeScalar(origin))
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "minShiftGapSeconds"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new BooleanField(
+                        SampleDatabase.Users.Entity,
+                        SampleDatabase.Users.Active
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<bool, double> expected = db.UserRows
+            .GroupBy(user => user.UserActive)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Min(user => (user.ShiftStart - origin).TotalSeconds)
+            );
+
+        Dictionary<bool, double> actual = result.Rows.ToDictionary(
+            row => row.Bool(SampleDatabase.Users.Active)!.Value,
+            row => row.Double("minShiftGapSeconds")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void CountOfEachArithmeticCountsGroupRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new NumberArrayReturning(
+                                        new EachArithmetic(
+                                            new EachAdd(
+                                                [
+                                                    new NumberArrayReturning(
+                                                        new NumberField(
+                                                            SampleDatabase.Orders.Entity,
+                                                            SampleDatabase.Orders.Total
+                                                        )
+                                                    ),
+                                                    new NumberReturning(
+                                                        new NumberScalar(1)
+                                                    ),
+                                                ]
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "rowCount"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = db.OrderRows
+            .GroupBy(order => order.OrderUserId)
+            .ToDictionary(group => group.Key, group => (double)group.Count());
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("rowCount")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Api/TableSchemaTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Api/TableSchemaTests.cs
@@ -1,8 +1,15 @@
 using Pure.RelationalSchema.Abstractions.Column;
 using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
 using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates.Date;
+using PureQL.CSharp.Model.Aggregates.DateTime;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.Aggregates.String;
+using PureQL.CSharp.Model.Aggregates.Time;
 using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
 using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Api;
 
@@ -68,6 +75,193 @@ public sealed class TableSchemaTests
         Assert.Equal(
             ["uuid", "string", "double"],
             [.. columns.Select(column => column.Type.Name.TextValue)]
+        );
+    }
+
+    [Fact]
+    public void TableSchemaColumnForAggregateFollowsAliasAndType()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "totalSum"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(
+                            new StringAggregate(
+                                new MaxString(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Status
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "maxStatus"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new DateReturning(
+                            new DateAggregate(
+                                new MaxDate(
+                                    new DateArrayReturning(
+                                        new DateField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.PlacedOn
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "maxPlacedOn"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new DateTimeReturning(
+                            new DateTimeAggregate(
+                                new MinDateTime(
+                                    new DateTimeArrayReturning(
+                                        new DateTimeField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.PlacedAt
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "minPlacedAt"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new TimeReturning(
+                            new TimeAggregate(
+                                new MaxTime(
+                                    new TimeArrayReturning(
+                                        new TimeField(
+                                            SampleDatabase.Users.Entity,
+                                            SampleDatabase.Users.ShiftStart
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "maxShiftStart"
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                ),
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        PureQLProjection projection = new PureQLProjection(db.Datasets, query);
+
+        IColumn[] columns = [.. projection.TableSchema.Columns];
+
+        Assert.Equal(
+            ["totalSum", "maxStatus", "maxPlacedOn", "minPlacedAt", "maxShiftStart"],
+            [.. columns.Select(column => column.Name.TextValue)]
+        );
+        Assert.Equal(
+            ["double", "string", "date", "datetime", "time"],
+            [.. columns.Select(column => column.Type.Name.TextValue)]
+        );
+    }
+
+    [Fact]
+    public void TableSchemaWithoutAliasesFallsBackToFieldNames()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Id
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                ),
+            ]
+        );
+
+        PureQLProjection projection = new PureQLProjection(db.Datasets, query);
+
+        IColumn[] columns = [.. projection.TableSchema.Columns];
+
+        Assert.Equal(
+            [SampleDatabase.Orders.Id, SampleDatabase.Orders.Status],
+            [.. columns.Select(column => column.Name.TextValue)]
+        );
+
+        ProjectionResult result = new ProjectionResult(projection);
+
+        Assert.Equal(
+            [.. columns.Select(column => column.Name.TextValue)],
+            result.ColumnNames
         );
     }
 }

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Combined/AggregatePipelineTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Combined/AggregatePipelineTests.cs
@@ -1,0 +1,640 @@
+using System.Globalization;
+using Pure.RelationalSchema.Abstractions.Column;
+using Pure.RelationalSchema.Storage.Abstractions;
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.Aggregates.String;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+using ModelPagination = PureQL.CSharp.Model.Pagination;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Combined;
+
+// Aggregates combined with the rest of the pipeline: WHERE narrows the rows
+// folded by GROUP BY, joins (same-schema and cross-schema) feed aggregates,
+// and whole-set aggregates (no groupBy) compose with a preceding WHERE.
+[Trait("Clause", "Combined")]
+[Trait("Feature", "AggregatePipeline")]
+public sealed class AggregatePipelineTests
+{
+    private static Join UsersToOrdersJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Orders.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static Join UsersToLoginsJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Logins.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Logins.Entity,
+                                SampleDatabase.Logins.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void WhereThenGroupByAggregatesOnlyFilteredRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "filteredSum"
+                ),
+            ],
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachStringEquality(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        ),
+                        new StringReturning(new StringScalar("shipped"))
+                    )
+                )
+            ),
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = db.OrderRows
+            .Where(order => order.OrderStatus == "shipped")
+            .GroupBy(order => order.OrderUserId)
+            .ToDictionary(group => group.Key, group => group.Sum(order => order.OrderTotal));
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("filteredSum")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void JoinThenGroupByProjectsAggregatePerJoinedGroup()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "orderCount"
+                ),
+            ],
+            where: null,
+            [UsersToOrdersJoin()],
+            [
+                new Field(
+                    new StringField(
+                        SampleDatabase.Users.Entity,
+                        SampleDatabase.Users.Name
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<string, double> expected = db.OrderRows
+            .Join(
+                db.UserRows,
+                order => order.OrderUserId,
+                user => user.UserId,
+                (order, user) => user.UserName
+            )
+            .GroupBy(name => name)
+            .ToDictionary(group => group.Key, group => (double)group.Count());
+
+        Dictionary<string, double> actual = result.Rows.ToDictionary(
+            row => row[SampleDatabase.Users.Name]!,
+            row => row.Double("orderCount")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void CrossSchemaJoinThenGroupByCountsPerUser()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Logins.Entity,
+                                            SampleDatabase.Logins.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "loginCount"
+                ),
+            ],
+            where: null,
+            [UsersToLoginsJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Users.Entity,
+                        SampleDatabase.Users.Id
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = db.LoginRows
+            .GroupBy(login => login.LoginUserId)
+            .ToDictionary(group => group.Key, group => (double)group.Count());
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Users.Id)!.Value,
+            row => row.Double("loginCount")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void GroupByHavingOrderByPaginationComposeInOrder()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "statusSum"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new StringField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.Status
+                    )
+                ),
+            ],
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.GreaterThan,
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(0))
+                    )
+                )
+            ),
+            [
+                new OrderByItem(
+                    new Field(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    SortDirection.Asc
+                ),
+            ],
+            new ModelPagination(1, 1)
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string Status, double Sum)[] expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderStatus)
+                .Where(group => group.Sum(order => order.OrderTotal) > 0)
+                .OrderBy(group => group.Key, StringComparer.Ordinal)
+                .Select(group => (group.Key, group.Sum(order => order.OrderTotal)))
+                .Skip(1)
+                .Take(1),
+        ];
+
+        (string Status, double Sum)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (row[SampleDatabase.Orders.Status]!, row.Double("statusSum")!.Value)
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void WholeSetAggregateOverFilteredRowsProjectsSingleRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "filteredSum"
+                ),
+            ],
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachStringEquality(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        ),
+                        new StringReturning(new StringScalar("shipped"))
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double expected = db.OrderRows
+            .Where(order => order.OrderStatus == "shipped")
+            .Sum(order => order.OrderTotal);
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expected, result.Row(0).Double("filteredSum"));
+    }
+
+    [Fact]
+    public void WholeSetCountProjectsSingleRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "total"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(db.OrderRows.Count, result.Row(0).Double("total"));
+    }
+
+    [Fact]
+    public void WholeSetMinAndMaxStringProjectInOneRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(
+                            new StringAggregate(
+                                new MinString(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Status
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "minStatus"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(
+                            new StringAggregate(
+                                new MaxString(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Status
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "maxStatus"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string expectedMin = db.OrderRows
+            .Select(order => order.OrderStatus)
+            .Min(StringComparer.Ordinal)!;
+        string expectedMax = db.OrderRows
+            .Select(order => order.OrderStatus)
+            .Max(StringComparer.Ordinal)!;
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expectedMin, result.Row(0)["minStatus"]);
+        Assert.Equal(expectedMax, result.Row(0)["maxStatus"]);
+    }
+
+    [Fact]
+    public async Task AsyncEnumerationYieldsGroupedAggregateRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "userTotal"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        PureQLProjection projection = new PureQLProjection(db.Datasets, query);
+
+        Dictionary<Guid, double> actual = [];
+        await foreach (IRow row in projection)
+        {
+            Guid userId = default;
+            double total = 0;
+            foreach (KeyValuePair<IColumn, ICell> cell in row.Cells)
+            {
+                if (cell.Key.Name.TextValue == SampleDatabase.Orders.UserId)
+                {
+                    userId = Guid.Parse(cell.Value.Value.TextValue!);
+                }
+                else if (cell.Key.Name.TextValue == "userTotal")
+                {
+                    total = double.Parse(
+                        cell.Value.Value.TextValue!,
+                        CultureInfo.InvariantCulture
+                    );
+                }
+            }
+
+            actual[userId] = total;
+        }
+
+        Dictionary<Guid, double> expected = db.OrderRows
+            .GroupBy(order => order.OrderUserId)
+            .ToDictionary(group => group.Key, group => group.Sum(order => order.OrderTotal));
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Combined/AggregatePipelineTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Combined/AggregatePipelineTests.cs
@@ -617,12 +617,12 @@ public sealed class AggregatePipelineTests
             {
                 if (cell.Key.Name.TextValue == SampleDatabase.Orders.UserId)
                 {
-                    userId = Guid.Parse(cell.Value.Value.TextValue!);
+                    userId = Guid.Parse(cell.Value.Value.TextValue);
                 }
                 else if (cell.Key.Name.TextValue == "userTotal")
                 {
                     total = double.Parse(
-                        cell.Value.Value.TextValue!,
+                        cell.Value.Value.TextValue,
                         CultureInfo.InvariantCulture
                     );
                 }

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/SampleDatabase.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/SampleDatabase.cs
@@ -254,6 +254,17 @@ internal sealed class SampleDatabase
             new DateTime(2024, 6, 4, 7, 5, 0),
             new TimeOnly(8, 0, 0)
         ),
+        // Shares SignupDate, LastLogin and ShiftStart with Ann, so those
+        // columns are discriminating for DISTINCT tests over each type.
+        new(
+            Id(6),
+            "Fay",
+            28,
+            true,
+            new DateOnly(2020, 1, 15),
+            new DateTime(2024, 6, 1, 8, 30, 0),
+            new TimeOnly(9, 0, 0)
+        ),
     ];
 
     public IReadOnlyList<OrderRow> OrderRows { get; } = [

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/HavingAggregateTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/HavingAggregateTests.cs
@@ -1,0 +1,570 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Date;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.Aggregates.String;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.BooleanOperations;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.Equalities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.GroupBy;
+
+// HAVING beyond a bare count comparison: aggregate comparisons over sum,
+// average, min/max (string and date), boolean composites, equality over an
+// aggregate, and the always-true/always-false boundary conditions. Orders
+// are grouped by their user; expected groups are computed from the
+// ground-truth records.
+[Trait("Clause", "GroupBy")]
+[Trait("Feature", "Having")]
+public sealed class HavingAggregateTests
+{
+    private static NumberReturning OrderCount()
+    {
+        return new NumberReturning(
+            new Count(
+                new ArrayReturning(
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Id
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static NumberArrayReturning Totals()
+    {
+        return new NumberArrayReturning(
+            new NumberField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Total)
+        );
+    }
+
+    private static NumberReturning SumTotal()
+    {
+        return new NumberReturning(new NumberAggregate(new SumNumber(Totals())));
+    }
+
+    private static NumberReturning AverageTotal()
+    {
+        return new NumberReturning(new NumberAggregate(new AverageNumber(Totals())));
+    }
+
+    private static NumberReturning MaxTotal()
+    {
+        return new NumberReturning(new NumberAggregate(new MaxNumber(Totals())));
+    }
+
+    private static StringReturning MinStatus()
+    {
+        return new StringReturning(
+            new StringAggregate(
+                new MinString(
+                    new StringArrayReturning(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static DateReturning MaxPlacedOn()
+    {
+        return new DateReturning(
+            new DateAggregate(
+                new MaxDate(
+                    new DateArrayReturning(
+                        new DateField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.PlacedOn
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static Query OrdersGroupedByUser(
+        BooleanReturning having,
+        string countAlias = "orderCount"
+    )
+    {
+        return new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(new SingleValueReturning(OrderCount()), countAlias),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            having,
+            orderBy: null,
+            pagination: null
+        );
+    }
+
+    [Fact]
+    public void HavingSumGreaterThanKeepsQualifyingGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.GreaterThan,
+                        SumTotal(),
+                        new NumberReturning(new NumberScalar(150))
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .Where(group => group.Sum(order => order.OrderTotal) > 150)
+                .Select(group => group.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row =>
+                row.Uuid(SampleDatabase.Orders.UserId)!.Value
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingAverageLessThanOrEqualKeepsQualifyingGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.LessThanOrEqual,
+                        AverageTotal(),
+                        new NumberReturning(new NumberScalar(100.50))
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .Where(group => group.Average(order => order.OrderTotal) <= 100.50)
+                .Select(group => group.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row =>
+                row.Uuid(SampleDatabase.Orders.UserId)!.Value
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingMinStringComparisonKeepsQualifyingGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new Comparison(
+                    new global::PureQL.CSharp.Model.Comparisons.StringComparison(
+                        ComparisonOperator.GreaterThanOrEqual,
+                        MinStatus(),
+                        new StringReturning(new StringScalar("pending"))
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .Where(group =>
+                    string.CompareOrdinal(
+                        group.Select(order => order.OrderStatus).Min(StringComparer.Ordinal),
+                        "pending"
+                    ) >= 0
+                )
+                .Select(group => group.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row =>
+                row.Uuid(SampleDatabase.Orders.UserId)!.Value
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingMaxDateComparisonKeepsQualifyingGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+        DateOnly threshold = new DateOnly(2024, 6, 4);
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new Comparison(
+                    new DateComparison(
+                        ComparisonOperator.LessThan,
+                        MaxPlacedOn(),
+                        new DateReturning(new DateScalar(threshold))
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .Where(group => group.Max(order => order.PlacedOn) < threshold)
+                .Select(group => group.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row =>
+                row.Uuid(SampleDatabase.Orders.UserId)!.Value
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingAndOfTwoAggregateComparisonsKeepsIntersection()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        BooleanReturning countGreaterThanOne = new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    ComparisonOperator.GreaterThan,
+                    OrderCount(),
+                    new NumberReturning(new NumberScalar(1))
+                )
+            )
+        );
+        BooleanReturning sumGreaterThan150 = new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    ComparisonOperator.GreaterThan,
+                    SumTotal(),
+                    new NumberReturning(new NumberScalar(150))
+                )
+            )
+        );
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new BooleanOperator(
+                    new AndOperator([countGreaterThanOne, sumGreaterThan150])
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .Where(group =>
+                    group.Count() > 1 && group.Sum(order => order.OrderTotal) > 150
+                )
+                .Select(group => group.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row =>
+                row.Uuid(SampleDatabase.Orders.UserId)!.Value
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingOrOfTwoAggregateComparisonsKeepsUnion()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        BooleanReturning countGreaterThanOne = new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    ComparisonOperator.GreaterThan,
+                    OrderCount(),
+                    new NumberReturning(new NumberScalar(1))
+                )
+            )
+        );
+        BooleanReturning sumGreaterThan150 = new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    ComparisonOperator.GreaterThan,
+                    SumTotal(),
+                    new NumberReturning(new NumberScalar(150))
+                )
+            )
+        );
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new BooleanOperator(
+                    new OrOperator([countGreaterThanOne, sumGreaterThan150])
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .Where(group =>
+                    group.Count() > 1 || group.Sum(order => order.OrderTotal) > 150
+                )
+                .Select(group => group.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row =>
+                row.Uuid(SampleDatabase.Orders.UserId)!.Value
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingNotInvertsAggregateComparison()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        BooleanReturning countGreaterThanOne = new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    ComparisonOperator.GreaterThan,
+                    OrderCount(),
+                    new NumberReturning(new NumberScalar(1))
+                )
+            )
+        );
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new BooleanOperator(new NotOperator(countGreaterThanOne))
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .Where(group => group.Count() <= 1)
+                .Select(group => group.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row =>
+                row.Uuid(SampleDatabase.Orders.UserId)!.Value
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingComparingTwoAggregatesOfSameGroupKeepsQualifyingGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.GreaterThan,
+                        MaxTotal(),
+                        AverageTotal()
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .Where(group =>
+                    group.Max(order => order.OrderTotal)
+                    > group.Average(order => order.OrderTotal)
+                )
+                .Select(group => group.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row =>
+                row.Uuid(SampleDatabase.Orders.UserId)!.Value
+            ),
+        ];
+
+        Assert.NotEmpty(expected);
+        Assert.True(expected.Count < db.OrderRows.Select(o => o.OrderUserId).Distinct().Count());
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingEqualityOverCountKeepsExactMatches()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(
+                new Equality(
+                    new SingleValueEquality(
+                        new NumberEquality(
+                            OrderCount(),
+                            new NumberReturning(new NumberScalar(2))
+                        )
+                    )
+                )
+            )
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .Where(group => group.Count() == 2)
+                .Select(group => group.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row =>
+                row.Uuid(SampleDatabase.Orders.UserId)!.Value
+            ),
+        ];
+
+        Assert.NotEmpty(expected);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingRejectingEveryGroupReturnsEmpty()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(new BooleanScalar(false))
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    [Fact]
+    public void HavingAcceptingEveryGroupKeepsAllGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = OrdersGroupedByUser(
+            new BooleanReturning(new BooleanScalar(true))
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedGroups = db.OrderRows
+            .Select(order => order.OrderUserId)
+            .Distinct()
+            .Count();
+
+        Assert.Equal(expectedGroups, result.Count);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/MixedProjectionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/GroupBy/MixedProjectionTests.cs
@@ -1,0 +1,493 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Date;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.Aggregates.String;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.GroupBy;
+
+// A group-mode select list may mix the grouping key with one or more
+// aggregates in a single row: each output row pairs the group's key value
+// with its folded aggregate value(s), not just the aggregate alone.
+[Trait("Clause", "GroupBy")]
+[Trait("Feature", "MixedProjection")]
+public sealed class MixedProjectionTests
+{
+    private static Join UsersToOrdersJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Orders.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void GroupKeyAndSumProjectTogetherPerGroup()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "userTotal"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = db.OrderRows
+            .GroupBy(order => order.OrderUserId)
+            .ToDictionary(group => group.Key, group => group.Sum(order => order.OrderTotal));
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("userTotal")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void GroupKeyAndCountProjectTogetherPerGroup()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "statusCount"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new StringField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.Status
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<string, double> expected = db.OrderRows
+            .GroupBy(order => order.OrderStatus)
+            .ToDictionary(group => group.Key, group => (double)group.Count());
+
+        Dictionary<string, double> actual = result.Rows.ToDictionary(
+            row => row[SampleDatabase.Orders.Status]!,
+            row => row.Double("statusCount")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MultipleAggregatesOfDifferentTypesProjectInOneRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "orderCount"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "totalSum"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new DateReturning(
+                            new DateAggregate(
+                                new MinDate(
+                                    new DateArrayReturning(
+                                        new DateField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.PlacedOn
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "earliestPlacedOn"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new StringReturning(
+                            new StringAggregate(
+                                new MaxString(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Status
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "maxStatus"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, (double Count, double Sum, DateOnly Min, string Max)> expected =
+            db.OrderRows
+                .GroupBy(order => order.OrderUserId)
+                .ToDictionary(
+                    group => group.Key,
+                    group => (
+                        Count: (double)group.Count(),
+                        Sum: group.Sum(order => order.OrderTotal),
+                        Min: group.Min(order => order.PlacedOn),
+                        Max: group.Select(order => order.OrderStatus)
+                            .Max(StringComparer.Ordinal)!
+                    )
+                );
+
+        Assert.Equal(expected.Count, result.Count);
+        Assert.All(
+            result.Rows,
+            row =>
+            {
+                Guid userId = row.Uuid(SampleDatabase.Orders.UserId)!.Value;
+                (double Count, double Sum, DateOnly Min, string Max) expectedGroup =
+                    expected[userId];
+                Assert.Equal(expectedGroup.Count, row.Double("orderCount"));
+                Assert.Equal(expectedGroup.Sum, row.Double("totalSum"));
+                Assert.Equal(expectedGroup.Min, row.Date("earliestPlacedOn"));
+                Assert.Equal(expectedGroup.Max, row["maxStatus"]);
+            }
+        );
+    }
+
+    [Fact]
+    public void TwoNumericAggregatesOverDifferentColumnsProjectIndependently()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "orderTotalSum"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new AverageNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Users.Entity,
+                                            SampleDatabase.Users.Age
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "avgAge"
+                ),
+            ],
+            where: null,
+            [UsersToOrdersJoin()],
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Users.Entity,
+                        SampleDatabase.Users.Id
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, (double Sum, double Avg)> expected = db.OrderRows
+            .Join(
+                db.UserRows,
+                order => order.OrderUserId,
+                user => user.UserId,
+                (order, user) => (user.UserId, order.OrderTotal, user.UserAge)
+            )
+            .GroupBy(row => row.UserId)
+            .ToDictionary(
+                group => group.Key,
+                group => (
+                    Sum: group.Sum(row => row.OrderTotal),
+                    Avg: group.Average(row => row.UserAge)
+                )
+            );
+
+        Assert.Equal(expected.Count, result.Count);
+        Assert.All(
+            result.Rows,
+            row =>
+            {
+                Guid userId = row.Uuid(SampleDatabase.Users.Id)!.Value;
+                (double Sum, double Avg) expectedGroup = expected[userId];
+                Assert.Equal(expectedGroup.Sum, row.Double("orderTotalSum"));
+                Assert.Equal(expectedGroup.Avg, row.Double("avgAge"));
+            }
+        );
+    }
+
+    [Fact]
+    public void AggregateColumnsFollowAliasesInMixedProjection()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    ),
+                    "buyer"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "purchases"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "spend"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(["buyer", "purchases", "spend"], result.ColumnNames);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/AliasCoverageTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/AliasCoverageTests.cs
@@ -1,0 +1,102 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Fields;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Select;
+
+// Aliases can cover every select item in a query, and an alias may collide
+// with a different source column's name without the projected value being
+// confused with that other column.
+[Trait("Clause", "Select")]
+[Trait("Feature", "SelectAlias")]
+public sealed class AliasCoverageTests
+{
+    [Fact]
+    public void AliasesOnEverySelectItemRenameAllColumns()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Id
+                            )
+                        )
+                    ),
+                    "id"
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    ),
+                    "state"
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        )
+                    ),
+                    "amount"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(["id", "state", "amount"], result.ColumnNames);
+        Assert.DoesNotContain(SampleDatabase.Orders.Id, result.ColumnNames);
+        Assert.DoesNotContain(SampleDatabase.Orders.Status, result.ColumnNames);
+        Assert.DoesNotContain(SampleDatabase.Orders.Total, result.ColumnNames);
+    }
+
+    [Fact]
+    public void AliasEqualToAnotherFieldNameShadowsInProjection()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    ),
+                    SampleDatabase.Orders.Total
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal([SampleDatabase.Orders.Total], result.ColumnNames);
+
+        string?[] expected = [.. db.OrderRows.Select(order => order.OrderStatus)];
+        string?[] actual = [.. result.Column(SampleDatabase.Orders.Total)];
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/DistinctInteractionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/DistinctInteractionTests.cs
@@ -1,0 +1,518 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using ModelPagination = PureQL.CSharp.Model.Pagination;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Select;
+
+// DISTINCT interacting with the rest of the pipeline: multi-column tuple
+// dedup, join fan-out collapse, ordering/pagination interplay, aliasing, and
+// the remaining typed columns of the seven-type matrix (date/number/uuid/
+// time/datetime; string and bool are covered by DistinctTests).
+[Trait("Clause", "Select")]
+[Trait("Feature", "Distinct")]
+public sealed class DistinctInteractionTests
+{
+    private static Join ItemsToProductsJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Products.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.ProductId
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Products.Entity,
+                                SampleDatabase.Products.Id
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    [Fact]
+    public void DistinctOnMultiColumnProjectionDeduplicatesTuples()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Age
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new BooleanArrayReturning(
+                            new BooleanField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Active
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (double, bool)[] expected =
+        [
+            .. db.UserRows
+                .Select(user => (user.UserAge, user.UserActive))
+                .Distinct()
+                .OrderBy(pair => pair.UserAge)
+                .ThenBy(pair => pair.UserActive),
+        ];
+
+        (double, bool)[] actual =
+        [
+            .. result.Rows
+                .Select(row =>
+                    (
+                        row.Double(SampleDatabase.Users.Age)!.Value,
+                        row.Bool(SampleDatabase.Users.Active)!.Value
+                    )
+                )
+                .OrderBy(pair => pair.Item1)
+                .ThenBy(pair => pair.Item2),
+        ];
+
+        Assert.True(expected.Length < db.UserRows.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DistinctCollapsesJoinFanOutDuplicates()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.OrderItems.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.OrderId
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [ItemsToProductsJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Guid[] expected =
+        [
+            .. db.OrderItemRows
+                .Select(item => item.ItemOrderId)
+                .Distinct()
+                .OrderBy(id => id),
+        ];
+
+        Guid[] actual =
+        [
+            .. result.Column(SampleDatabase.OrderItems.OrderId)
+                .Select(text => Guid.Parse(text!))
+                .OrderBy(id => id),
+        ];
+
+        Assert.True(expected.Length < db.OrderItemRows.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DistinctPreservesFirstOccurrenceOrderAfterOrderBy()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    SortDirection.Desc
+                ),
+            ],
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.OrderRows
+                .Select(order => order.OrderStatus)
+                .OrderByDescending(status => status, StringComparer.Ordinal)
+                .Distinct(),
+        ];
+
+        string?[] actual = [.. result.Column(SampleDatabase.Orders.Status)];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DistinctAppliesBeforePagination()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    SortDirection.Asc
+                ),
+            ],
+            new ModelPagination(0, 2),
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.OrderRows
+                .Select(order => order.OrderStatus)
+                .Distinct()
+                .OrderBy(status => status, StringComparer.Ordinal)
+                .Take(2),
+        ];
+
+        string?[] actual = [.. result.Column(SampleDatabase.Orders.Status)];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void DistinctOnAliasedColumnDeduplicatesProjectedValues()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    ),
+                    "state"
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Contains("state", result.ColumnNames);
+        Assert.Equal(
+            db.OrderRows.Select(order => order.OrderStatus).Distinct().Count(),
+            result.Count
+        );
+    }
+
+    [Fact]
+    public void DistinctOnDateColumnCollapsesDuplicateValues()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new DateArrayReturning(
+                            new DateField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.SignupDate
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedDistinct = db.UserRows
+            .Select(user => user.SignupDate)
+            .Distinct()
+            .Count();
+
+        Assert.True(expectedDistinct < db.UserRows.Count);
+        Assert.Equal(expectedDistinct, result.Count);
+    }
+
+    [Fact]
+    public void DistinctOnNumberColumnCollapsesDuplicateValues()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedDistinct = db.OrderRows
+            .Select(order => order.OrderTotal)
+            .Distinct()
+            .Count();
+
+        Assert.True(expectedDistinct < db.OrderRows.Count);
+        Assert.Equal(expectedDistinct, result.Count);
+    }
+
+    [Fact]
+    public void DistinctOnUuidColumnCollapsesDuplicateValues()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedDistinct = db.OrderRows
+            .Select(order => order.OrderUserId)
+            .Distinct()
+            .Count();
+
+        Assert.True(expectedDistinct < db.OrderRows.Count);
+        Assert.Equal(expectedDistinct, result.Count);
+    }
+
+    [Fact]
+    public void DistinctOnTimeColumnCollapsesDuplicateValues()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new TimeArrayReturning(
+                            new TimeField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.ShiftStart
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedDistinct = db.UserRows
+            .Select(user => user.ShiftStart)
+            .Distinct()
+            .Count();
+
+        Assert.True(expectedDistinct < db.UserRows.Count);
+        Assert.Equal(expectedDistinct, result.Count);
+    }
+
+    [Fact]
+    public void DistinctOnDateTimeColumnCollapsesDuplicateValues()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new DateTimeArrayReturning(
+                            new DateTimeField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.LastLogin
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedDistinct = db.UserRows
+            .Select(user => user.LastLogin)
+            .Distinct()
+            .Count();
+
+        Assert.True(expectedDistinct < db.UserRows.Count);
+        Assert.Equal(expectedDistinct, result.Count);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/EmptyResultTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/EmptyResultTests.cs
@@ -1,6 +1,8 @@
 using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
 using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
 using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
 using PureQL.CSharp.Model.EachEqualities;
 using PureQL.CSharp.Model.Fields;
 using PureQL.CSharp.Model.Returnings;
@@ -200,6 +202,136 @@ public sealed class EmptyResultTests
             having: null,
             orderBy: null,
             new global::PureQL.CSharp.Model.Pagination(0, 5)
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    [Fact]
+    public void WhereMatchingNothingWithGroupByReturnsNoGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "orderCount"
+                ),
+            ],
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachStringEquality(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        ),
+                        new StringReturning(new StringScalar("no-such-status"))
+                    )
+                )
+            ),
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    [Fact]
+    public void HavingFilteringEveryGroupReturnsEmpty()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new UuidField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.UserId
+                    )
+                ),
+            ],
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.GreaterThan,
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(999))
+                    )
+                )
+            ),
+            orderBy: null,
+            pagination: null
         );
 
         ProjectionResult result = new ProjectionResult(


### PR DESCRIPTION
## Summary
- Implements the test batch scoped in #75 (part of the #72 roadmap): aggregates over `each*` arguments, paired key+aggregate group projections, HAVING beyond `count`, aggregate pipeline combinations (join/where/order/paginate composed with GROUP BY), DISTINCT interactions across the full 7-type matrix, select alias coverage, and empty-result edges for group/having.
- Extends `SampleDatabase` with one row sharing `SignupDate`/`LastLogin`/`ShiftStart` with an existing row, needed to make the date/datetime/time legs of the DISTINCT type matrix genuinely discriminating. Verified no existing test's hardcoded row-count assertion breaks.
- All tests follow the existing suite conventions: fully explicit inline `PureQL.CSharp.Model` construction, `SampleDatabase` ground truth, `Clause`/`Feature` traits.
- No `KnownGap` skips were needed — every test in #75's spec exercises already-implemented behavior.

Closes #75

## Test plan
- [x] `dotnet build --no-restore -warnaserror` — clean
- [x] `dotnet test --no-build --verbosity normal` — 270/270 passed (228 pre-existing + 42 new, no regressions)
- [x] `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)