### PR TITLE
Fix: reject self-joins instead of silently returning a cross product

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/EntityReferenceValidator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/EntityReferenceValidator.cs
@@ -39,6 +39,18 @@ internal static class EntityReferenceValidator
         {
             foreach (Join join in query.Join)
             {
+                if (known.Comparer.Equals(join.Entity, query.From.Entity))
+                {
+                    throw new NotSupportedException(
+                        $"Join entity '{join.Entity}' equals the from "
+                            + $"entity '{query.From.Entity}'. Self-joins "
+                            + "are not supported: joins have no per-join "
+                            + "alias, so both sides would resolve to the "
+                            + "same column and any ON condition would "
+                            + "become tautological."
+                    );
+                }
+
                 _ = known.Add(join.Entity);
             }
         }

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/SelfJoinTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/SelfJoinTests.cs
@@ -1,0 +1,75 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+// Joins have no per-join alias (see UndeclaredAliasEntityTests), so a join
+// whose entity equals the from entity gives both sides of the ON condition
+// the identical entity string. CellValueExtractor.GetCell always prefers the
+// QualifiedColumn matching the reference's entity, so both left.field and
+// right.field resolve to the same (joined-side) cell, making any equi-join
+// condition tautological and silently returning the full cross product
+// instead of a correct self-join (issue #109). This is rejected fast rather
+// than producing a wrong answer.
+[Trait("Clause", "Join")]
+[Trait("Feature", "SelfJoin")]
+public sealed class SelfJoinTests
+{
+    [Fact]
+    public void JoinOnSameEntityAsFromFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                ),
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+}


### PR DESCRIPTION
## Summary
- `EntityReferenceValidator.Validate` never rejected a `Join` whose entity equals the query's FROM entity. Because joins have no per-join alias, both sides of a self-join share the identical entity string, and `CellValueExtractor.GetCell` always prefers the `QualifiedColumn` matching the reference's entity — so every field reference on either side resolved to the *same* (joined-side) cell, making any equi-join ON condition tautological.
- Empirically confirmed: self-joining a 6-row table on `id == id` returned the full 36-row cross product instead of erroring or joining correctly — a silent-wrong-answer bug, not a defined failure.
- Fixes it by rejecting self-joins with `NotSupportedException` at validation time, matching this project's established fail-fast contract for other unsupported constructs (parameter binding, computed select columns, aggregates-in-where — see CLAUDE.md's "Known execution gaps").
- Adds `Joins/SelfJoinTests.cs` pinning the new contract.
- Confirmed no existing test relied on the old silent cross-product behavior (no test in the suite joins an entity to itself).

Fixes #109

## Test plan
- [x] `dotnet build --no-restore -warnaserror` — clean
- [x] `dotnet test --no-build --verbosity normal` — 306 total, 303 passed, 3 skipped (pre-existing KnownGap), 0 failed — no regressions
- [x] `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)