### PR TITLE
Test suite: Where each* family, 5-level nesting and array-equality semantics

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/ArrayEqualitySequenceTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/ArrayEqualitySequenceTests.cs
@@ -1,0 +1,176 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayEqualities;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// Whole-array `equal` (`Equality` -> `ArrayEquality`, distinct from the
+// per-row `eachEqual` family exercised elsewhere in Where/Each) is a
+// single-value predicate: it evaluates once for the whole query rather than
+// per row, exactly like the scalar `and`/`or`/`not` family in
+// Where/Scalar/NestedBooleanTests. Reading WhereExpressionBuilder.cs
+// (BuildContainmentEquality) confirms two distinct, already-implemented
+// paths depending on operand shape:
+//   - literal array vs. literal array -> true SequenceEqual (order-sensitive,
+//     evaluated once).
+//   - field vs. literal array -> per-row Enumerable.Contains membership
+//     (order-insensitive "IN"), which is the genuine #98/#72 KnownGap: SQL
+//     result-set semantics say "column-as-a-whole-array equal literal-array"
+//     should also be an order-sensitive sequence comparison, not membership.
+[Trait("Clause", "Where")]
+[Trait("Feature", "ArrayEqualitySequence")]
+public sealed class ArrayEqualitySequenceTests
+{
+    private static SelectExpression OrderIdSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new UuidArrayReturning(
+                    new UuidField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Id)
+                )
+            )
+        );
+    }
+
+    // Two identical literal arrays: SequenceEqual is true, so the predicate
+    // (evaluated once, applied to the whole result) keeps every row.
+    [Fact]
+    public void WholeArrayEqualityOfTwoEqualLiteralArraysKeepsEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new NumberArrayEquality(
+                            new NumberArrayReturning(
+                                new NumberArrayScalar([1, 2, 3])
+                            ),
+                            new NumberArrayReturning(
+                                new NumberArrayScalar([1, 2, 3])
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count, result.Count);
+    }
+
+    // Two literal arrays with the same length but a different order:
+    // SequenceEqual is false (order-sensitive), so every row is removed.
+    [Fact]
+    public void WholeArrayEqualityOfTwoDifferentlyOrderedLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new NumberArrayEquality(
+                            new NumberArrayReturning(
+                                new NumberArrayScalar([1, 2, 3])
+                            ),
+                            new NumberArrayReturning(
+                                new NumberArrayScalar([3, 2, 1])
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // KnownGap: `order_total equal [reverse of the six order totals]` is,
+    // per SQL result-set/sequence-equality semantics, a single whole-array
+    // comparison - the column's values in row order do not equal the
+    // reversed literal, so the (once-evaluated) predicate should be false
+    // and the whole result set empty. The translator instead evaluates this
+    // shape as a per-row membership check (`order_total IN (...)`): since
+    // reversing doesn't change set membership, every row's own total is
+    // still present somewhere in the literal, so all six rows are kept.
+    [Fact(
+        Skip = "KnownGap: whole-array `equal` between a field and a literal "
+            + "array evaluates as per-row membership (Enumerable.Contains) "
+            + "instead of a single order-sensitive sequence-equality "
+            + "comparison across the whole column; see "
+            + "Semantics/README.md and epic #72 decision 7."
+    )]
+    [Trait("Status", "KnownGap")]
+    public void WholeArrayEqualityOfFieldAgainstReversedLiteralRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        double[] reversedTotals =
+        [
+            .. db.OrderRows.Select(order => order.OrderTotal).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new NumberArrayEquality(
+                            new NumberArrayReturning(
+                                new NumberField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Total
+                                )
+                            ),
+                            new NumberArrayReturning(
+                                new NumberArrayScalar(reversedTotals)
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        // Spec-correct (sequence equality): the column's total values, in
+        // row order, are not equal to the reversed literal, so the
+        // whole-query predicate is false and nothing is kept.
+        Assert.Equal(0, result.Count);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/EachBroadcastAndLiteralTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/EachBroadcastAndLiteralTests.cs
@@ -1,0 +1,347 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.EachArithmetics;
+using PureQL.CSharp.Model.EachBooleanOperations;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// Confirms two corrected #98 behaviours read straight from
+// WhereExpressionBuilder.cs source (see Semantics/README.md): a literal
+// array operand is never zipped by row index - every per-row evaluation
+// uses only the literal's first element (`.FirstOrDefault()`), broadcast to
+// every row regardless of the literal's declared length; and eachDivide by
+// zero returns null for that row rather than throwing. Also covers mixing a
+// scalar-broadcast operand with a per-row array-aligned operand within the
+// same predicate.
+[Trait("Clause", "Where")]
+[Trait("Feature", "EachBroadcastAndLiteral")]
+public sealed class EachBroadcastAndLiteralTests
+{
+    private static SelectExpression OrderIdSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new UuidArrayReturning(
+                    new UuidField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Id)
+                )
+            )
+        );
+    }
+
+    // eachAnd(total > 50 [broadcast scalar], total >= total [array-aligned,
+    // trivially true every row]) combines both operand kinds in one tree.
+    [Fact]
+    public void BroadcastScalarOperandAndArrayAlignedOperandCombineInSamePredicate()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachAndOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachComparison(
+                                new EachNumberComparison(
+                                    EachComparisonOperator.EachGreaterThan,
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    ),
+                                    new NumberReturning(new NumberScalar(50))
+                                )
+                            )
+                        ),
+                        new BooleanArrayReturning(
+                            new EachComparison(
+                                new EachNumberComparison(
+                                    EachComparisonOperator.EachGreaterThanOrEqual,
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    ),
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                    ]
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count(o => o.OrderTotal > 50), result.Count);
+    }
+
+    // A 2-element literal array ([999, -5]) compared against a 6-row table:
+    // if the literal were zipped by row index, only rows 0-1 would have a
+    // defined comparison and the rest would need a fallback. Actual
+    // behaviour broadcasts the literal's first element (999) to every row,
+    // regardless of the literal's declared length (2) or the row count (6),
+    // so every row satisfies `999 > total` (max total is 300).
+    [Fact]
+    public void LiteralNumberArrayOperandBroadcastsFirstElementRegardlessOfLength()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachComparison(
+                    new EachNumberComparison(
+                        EachComparisonOperator.EachGreaterThan,
+                        new NumberArrayReturning(
+                            new NumberArrayScalar([999, -5])
+                        ),
+                        new NumberReturning(new NumberScalar(0))
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        // Every row keeps: 999 (first literal element) > 0. A row-index zip
+        // would instead only define rows 0-1 and leave the rest ambiguous.
+        Assert.Equal(db.OrderRows.Count, result.Count);
+    }
+
+    // A 6-element literal string array whose *first* element is "shipped"
+    // and whose remaining five are junk values broadcasts "shipped" to
+    // every row's equality check against the (array-aligned) status field,
+    // rather than zipping element[i] against row[i]'s status.
+    [Fact]
+    public void LiteralStringArrayOperandBroadcastsFirstElementOnEqualityCheck()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        // The literal array is the left operand, checked per row against the
+        // (per-row, array-aligned) status field on the right. If the literal
+        // were zipped by row index, only row 0 could ever match (its own
+        // index carries "shipped"); broadcast means every row is compared
+        // against literal[0] = "shipped" instead.
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachStringEquality(
+                        new StringArrayReturning(
+                            new StringArrayScalar(
+                                [
+                                    "shipped",
+                                    "zzz",
+                                    "zzz",
+                                    "zzz",
+                                    "zzz",
+                                    "zzz",
+                                ]
+                            )
+                        ),
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(
+            db.OrderRows.Count(o => o.OrderStatus == "shipped"),
+            result.Count
+        );
+    }
+
+    // eachDivide by zero yields null for that row (DivideDoubles), and null
+    // never compares equal to a finite literal - it does not throw, and the
+    // equality check is false for every row (no exception propagates out of
+    // PureQLProjection construction or enumeration).
+    [Fact]
+    public void EachDivideByZeroYieldsNullNeverEqualToAFiniteLiteral()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachNumberEquality(
+                        new NumberArrayReturning(
+                            new EachArithmetic(
+                                new EachDivide(
+                                    [
+                                        new NumberArrayReturning(
+                                            new NumberField(
+                                                SampleDatabase.Orders.Entity,
+                                                SampleDatabase.Orders.Total
+                                            )
+                                        ),
+                                        new NumberReturning(new NumberScalar(0)),
+                                    ]
+                                )
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(0))
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Same eachDivide-by-zero result compared with a per-row comparison
+    // instead of equality: a lifted-nullable GreaterThan against null is
+    // false, never a thrown DivideByZeroException.
+    [Fact]
+    public void EachDivideByZeroYieldsNullNeverGreaterThanZero()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachComparison(
+                    new EachNumberComparison(
+                        EachComparisonOperator.EachGreaterThan,
+                        new NumberArrayReturning(
+                            new EachArithmetic(
+                                new EachDivide(
+                                    [
+                                        new NumberArrayReturning(
+                                            new NumberField(
+                                                SampleDatabase.Orders.Entity,
+                                                SampleDatabase.Orders.Total
+                                            )
+                                        ),
+                                        new NumberReturning(new NumberScalar(0)),
+                                    ]
+                                )
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(0))
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // eachDivide by zero, wrapped in eachNot(eachEquality(x, x)): null == null
+    // is true under lifted nullable equality (mirroring plain C# `(double?)
+    // null == (double?)null`), so negating it removes every row - the clearest
+    // possible signal that the division result is a deterministic null, not
+    // an exception and not some other sentinel value.
+    [Fact]
+    public void EachDivideByZeroResultEqualsItselfUnderLiftedNullEquality()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        NumberArrayReturning divideByZero = new NumberArrayReturning(
+            new EachArithmetic(
+                new EachDivide(
+                    [
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(0)),
+                    ]
+                )
+            )
+        );
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachNotOperator(
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachNumberEquality(divideByZero, divideByZero)
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/NestedEachTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/NestedEachTests.cs
@@ -1,0 +1,919 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachArithmetics;
+using PureQL.CSharp.Model.EachBooleanOperations;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// Deep nesting of the per-row (each*) boolean family (eachAnd/eachOr/eachNot
+// composing eachEquality/eachComparison/eachArithmetic leaves), at increasing
+// depth (2 through 5 levels), plus the other batch items from issue #98:
+// mixed arithmetic+boolean nesting, each* over joined columns inside a
+// nested tree, and negative/empty cases. Unlike the scalar family
+// (NestedBooleanTests), each leaf here reads a real per-row field, so the
+// keep/remove outcome varies row by row rather than being all-or-nothing;
+// every test derives the expected per-row truth value inline and cross-checks
+// against a LINQ-equivalent predicate over SampleDatabase.
+[Trait("Clause", "Where")]
+[Trait("Feature", "NestedEach")]
+public sealed class NestedEachTests
+{
+    private static SelectExpression OrderIdSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new UuidArrayReturning(
+                    new UuidField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Id)
+                )
+            )
+        );
+    }
+
+    // 2-level: eachAnd(total > 100, status == "shipped")
+    [Fact]
+    public void TwoLevelEachAndOfComparisonAndEqualityFiltersByBothConditions()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachAndOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachComparison(
+                                new EachNumberComparison(
+                                    EachComparisonOperator.EachGreaterThan,
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    ),
+                                    new NumberReturning(new NumberScalar(100))
+                                )
+                            )
+                        ),
+                        new BooleanArrayReturning(
+                            new EachEquality(
+                                new EachStringEquality(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Status
+                                        )
+                                    ),
+                                    new StringReturning(new StringScalar("shipped"))
+                                )
+                            )
+                        ),
+                    ]
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(
+            db.OrderRows.Count(o => o.OrderTotal > 100 && o.OrderStatus == "shipped"),
+            result.Count
+        );
+    }
+
+    // 2-level: eachOr(eachNot(status == "cancelled"), total < 0)
+    [Fact]
+    public void TwoLevelEachOrOfNotAndComparisonFiltersByEitherCondition()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachOrOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachNotOperator(
+                                new BooleanArrayReturning(
+                                    new EachEquality(
+                                        new EachStringEquality(
+                                            new StringArrayReturning(
+                                                new StringField(
+                                                    SampleDatabase.Orders.Entity,
+                                                    SampleDatabase.Orders.Status
+                                                )
+                                            ),
+                                            new StringReturning(
+                                                new StringScalar("cancelled")
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        new BooleanArrayReturning(
+                            new EachComparison(
+                                new EachNumberComparison(
+                                    EachComparisonOperator.EachLessThan,
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    ),
+                                    new NumberReturning(new NumberScalar(0))
+                                )
+                            )
+                        ),
+                    ]
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(
+            db.OrderRows.Count(o => o.OrderStatus != "cancelled" || o.OrderTotal < 0),
+            result.Count
+        );
+    }
+
+    // 3-level: eachAnd(eachOr(total >= 200, status == "pending"),
+    //                   eachNot(status == "cancelled"))
+    [Fact]
+    public void ThreeLevelEachAndOfOrAndNotFiltersByCombinedCondition()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        BooleanArrayReturning totalAtLeast200 = new BooleanArrayReturning(
+            new EachComparison(
+                new EachNumberComparison(
+                    EachComparisonOperator.EachGreaterThanOrEqual,
+                    new NumberArrayReturning(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(200))
+                )
+            )
+        );
+        BooleanArrayReturning statusPending = new BooleanArrayReturning(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    new StringReturning(new StringScalar("pending"))
+                )
+            )
+        );
+        BooleanArrayReturning statusCancelled = new BooleanArrayReturning(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    new StringReturning(new StringScalar("cancelled"))
+                )
+            )
+        );
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachAndOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachOrOperator([totalAtLeast200, statusPending])
+                        ),
+                        new BooleanArrayReturning(new EachNotOperator(statusCancelled)),
+                    ]
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(
+            db.OrderRows.Count(o =>
+                (o.OrderTotal >= 200 || o.OrderStatus == "pending")
+                && o.OrderStatus != "cancelled"
+            ),
+            result.Count
+        );
+    }
+
+    // 3-level, mixed arithmetic + boolean:
+    //   eachAnd(eachComparison(eachAdd(total, 50) > 150),
+    //           eachOr(status == "shipped", total < 60))
+    [Fact]
+    public void ThreeLevelPerRowArithmeticInsideComparisonInsideEachAndFilters()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachAndOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachComparison(
+                                new EachNumberComparison(
+                                    EachComparisonOperator.EachGreaterThan,
+                                    new NumberArrayReturning(
+                                        new EachArithmetic(
+                                            new EachAdd(
+                                                [
+                                                    new NumberArrayReturning(
+                                                        new NumberField(
+                                                            SampleDatabase.Orders.Entity,
+                                                            SampleDatabase.Orders.Total
+                                                        )
+                                                    ),
+                                                    new NumberReturning(
+                                                        new NumberScalar(50)
+                                                    ),
+                                                ]
+                                            )
+                                        )
+                                    ),
+                                    new NumberReturning(new NumberScalar(150))
+                                )
+                            )
+                        ),
+                        new BooleanArrayReturning(
+                            new EachOrOperator(
+                                [
+                                    new BooleanArrayReturning(
+                                        new EachEquality(
+                                            new EachStringEquality(
+                                                new StringArrayReturning(
+                                                    new StringField(
+                                                        SampleDatabase.Orders.Entity,
+                                                        SampleDatabase.Orders.Status
+                                                    )
+                                                ),
+                                                new StringReturning(
+                                                    new StringScalar("shipped")
+                                                )
+                                            )
+                                        )
+                                    ),
+                                    new BooleanArrayReturning(
+                                        new EachComparison(
+                                            new EachNumberComparison(
+                                                EachComparisonOperator.EachLessThan,
+                                                new NumberArrayReturning(
+                                                    new NumberField(
+                                                        SampleDatabase.Orders.Entity,
+                                                        SampleDatabase.Orders.Total
+                                                    )
+                                                ),
+                                                new NumberReturning(new NumberScalar(60))
+                                            )
+                                        )
+                                    ),
+                                ]
+                            )
+                        ),
+                    ]
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(
+            db.OrderRows.Count(o =>
+                o.OrderTotal + 50 > 150
+                && (o.OrderStatus == "shipped" || o.OrderTotal < 60)
+            ),
+            result.Count
+        );
+    }
+
+    // 4-level: eachAnd(eachOr(eachNot(eachAnd(total > 90, status == "shipped")),
+    //                          total >= 300),
+    //                   eachNot(status == "cancelled"))
+    [Fact]
+    public void FourLevelEachAndOrNotTreeFiltersByCombinedCondition()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        BooleanArrayReturning a = new BooleanArrayReturning(
+            new EachComparison(
+                new EachNumberComparison(
+                    EachComparisonOperator.EachGreaterThan,
+                    new NumberArrayReturning(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(90))
+                )
+            )
+        );
+        BooleanArrayReturning b = new BooleanArrayReturning(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    new StringReturning(new StringScalar("shipped"))
+                )
+            )
+        );
+        BooleanArrayReturning c = new BooleanArrayReturning(
+            new EachComparison(
+                new EachNumberComparison(
+                    EachComparisonOperator.EachGreaterThanOrEqual,
+                    new NumberArrayReturning(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(300))
+                )
+            )
+        );
+        BooleanArrayReturning d = new BooleanArrayReturning(
+            new EachNotOperator(
+                new BooleanArrayReturning(
+                    new EachEquality(
+                        new EachStringEquality(
+                            new StringArrayReturning(
+                                new StringField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Status
+                                )
+                            ),
+                            new StringReturning(new StringScalar("cancelled"))
+                        )
+                    )
+                )
+            )
+        );
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachAndOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachOrOperator(
+                                [
+                                    new BooleanArrayReturning(
+                                        new EachNotOperator(
+                                            new BooleanArrayReturning(
+                                                new EachAndOperator([a, b])
+                                            )
+                                        )
+                                    ),
+                                    c,
+                                ]
+                            )
+                        ),
+                        d,
+                    ]
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(
+            db.OrderRows.Count(o =>
+                (!(o.OrderTotal > 90 && o.OrderStatus == "shipped") || o.OrderTotal >= 300)
+                && o.OrderStatus != "cancelled"
+            ),
+            result.Count
+        );
+    }
+
+    // 5-level tree, AND-rooted:
+    //   eachAnd(
+    //     eachOr(eachNot(eachAnd(a, b)), c),
+    //     eachOr(eachNot(d), eachAnd(e, f))
+    //   )
+    // where, per row:
+    //   a = total > 100          b = status == "pending"
+    //   c = total >= 300         d = status == "cancelled"
+    //   e = total < 100          f = status == "shipped"
+    //
+    // Per-row derivation (order id / total / status):
+    //   101 / 100.50 / shipped   : a=T b=F -> and=F -> not=T -> left=T.
+    //                              d=F -> not=T -> right=T. root = T AND T = T.
+    //   102 /  50.00 / pending   : a=F b=T -> and=F -> not=T -> left=T.
+    //                              d=F -> not=T -> right=T. root = T.
+    //   103 / 200.00 / shipped   : a=T b=F -> and=F -> not=T -> left=T.
+    //                              d=F -> not=T -> right=T. root = T.
+    //   104 /  75.25 / cancelled : a=F b=F -> and=F -> not=T -> left=T.
+    //                              d=T -> not=F. e=T f=F -> and=F.
+    //                              right = F OR F = F. root = T AND F = F.
+    //   105 / 300.00 / shipped   : a=T b=F -> and=F -> not=T -> left=T.
+    //                              d=F -> not=T -> right=T. root = T.
+    //   106 / 100.50 / pending   : a=T b=T -> and=T -> not=F.
+    //                              c=100.50>=300=F -> left = F OR F = F.
+    //                              root = F AND (anything) = F.
+    //
+    // Kept: 101, 102, 103, 105. Removed: 104, 106.
+    [Fact]
+    public void FiveLevelAndRootedTreeMatchesRowByRowAgainstLinqPredicate()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        BooleanArrayReturning a = new BooleanArrayReturning(
+            new EachComparison(
+                new EachNumberComparison(
+                    EachComparisonOperator.EachGreaterThan,
+                    new NumberArrayReturning(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(100))
+                )
+            )
+        );
+        BooleanArrayReturning b = new BooleanArrayReturning(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    new StringReturning(new StringScalar("pending"))
+                )
+            )
+        );
+        BooleanArrayReturning c = new BooleanArrayReturning(
+            new EachComparison(
+                new EachNumberComparison(
+                    EachComparisonOperator.EachGreaterThanOrEqual,
+                    new NumberArrayReturning(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(300))
+                )
+            )
+        );
+        BooleanArrayReturning d = new BooleanArrayReturning(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    new StringReturning(new StringScalar("cancelled"))
+                )
+            )
+        );
+        BooleanArrayReturning e = new BooleanArrayReturning(
+            new EachComparison(
+                new EachNumberComparison(
+                    EachComparisonOperator.EachLessThan,
+                    new NumberArrayReturning(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(100))
+                )
+            )
+        );
+        BooleanArrayReturning f = new BooleanArrayReturning(
+            new EachEquality(
+                new EachStringEquality(
+                    new StringArrayReturning(
+                        new StringField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Status
+                        )
+                    ),
+                    new StringReturning(new StringScalar("shipped"))
+                )
+            )
+        );
+
+        BooleanArrayReturning leftBranch = new BooleanArrayReturning(
+            new EachOrOperator(
+                [
+                    new BooleanArrayReturning(
+                        new EachNotOperator(
+                            new BooleanArrayReturning(new EachAndOperator([a, b]))
+                        )
+                    ),
+                    c,
+                ]
+            )
+        );
+        BooleanArrayReturning rightBranch = new BooleanArrayReturning(
+            new EachOrOperator(
+                [
+                    new BooleanArrayReturning(new EachNotOperator(d)),
+                    new BooleanArrayReturning(new EachAndOperator([e, f])),
+                ]
+            )
+        );
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachAndOperator([leftBranch, rightBranch])
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Guid[] expected =
+        [
+            .. db.OrderRows
+                .Where(o =>
+                {
+                    bool av = o.OrderTotal > 100;
+                    bool bv = o.OrderStatus == "pending";
+                    bool cv = o.OrderTotal >= 300;
+                    bool dv = o.OrderStatus == "cancelled";
+                    bool ev = o.OrderTotal < 100;
+                    bool fv = o.OrderStatus == "shipped";
+                    bool left = !(av && bv) || cv;
+                    bool right = !dv || (ev && fv);
+                    return left && right;
+                })
+                .Select(o => o.OrderId)
+                .OrderBy(id => id),
+        ];
+
+        Guid[] actual =
+        [
+            .. result.Rows
+                .Select(row => row.Uuid(SampleDatabase.Orders.Id)!.Value)
+                .OrderBy(id => id),
+        ];
+
+        Assert.Equal(4, expected.Length);
+        Assert.Equal(expected, actual);
+    }
+
+    // Each* predicate over joined columns nested three levels deep:
+    //   eachAnd(eachOr(user_age > 28, order_status == "pending"),
+    //           eachNot(user_active == false))
+    [Fact]
+    public void EachTreeOverJoinedColumnsNestedInsideEachAndFiltersByBothSides()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachAndOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachOrOperator(
+                                [
+                                    new BooleanArrayReturning(
+                                        new EachComparison(
+                                            new EachNumberComparison(
+                                                EachComparisonOperator.EachGreaterThan,
+                                                new NumberArrayReturning(
+                                                    new NumberField(
+                                                        SampleDatabase.Users.Entity,
+                                                        SampleDatabase.Users.Age
+                                                    )
+                                                ),
+                                                new NumberReturning(new NumberScalar(28))
+                                            )
+                                        )
+                                    ),
+                                    new BooleanArrayReturning(
+                                        new EachEquality(
+                                            new EachStringEquality(
+                                                new StringArrayReturning(
+                                                    new StringField(
+                                                        SampleDatabase.Orders.Entity,
+                                                        SampleDatabase.Orders.Status
+                                                    )
+                                                ),
+                                                new StringReturning(
+                                                    new StringScalar("pending")
+                                                )
+                                            )
+                                        )
+                                    ),
+                                ]
+                            )
+                        ),
+                        new BooleanArrayReturning(
+                            new EachNotOperator(
+                                new BooleanArrayReturning(
+                                    new EachEquality(
+                                        new EachBooleanEquality(
+                                            new BooleanArrayReturning(
+                                                new BooleanField(
+                                                    SampleDatabase.Users.Entity,
+                                                    SampleDatabase.Users.Active
+                                                )
+                                            ),
+                                            new BooleanReturning(new BooleanScalar(false))
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                    ]
+                )
+            ),
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachEquality(
+                            new EachUuidEquality(
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.UserId
+                                    )
+                                ),
+                                new UuidArrayReturning(
+                                    new UuidField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Id
+                                    )
+                                )
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Guid[] expected =
+        [
+            .. db.OrderRows
+                .Where(o =>
+                {
+                    UserRow user = db.UserRows.Single(u => u.UserId == o.OrderUserId);
+                    return (user.UserAge > 28 || o.OrderStatus == "pending")
+                        && user.UserActive;
+                })
+                .Select(o => o.OrderId)
+                .OrderBy(id => id),
+        ];
+
+        Guid[] actual =
+        [
+            .. result.Rows
+                .Select(row => row.Uuid(SampleDatabase.Orders.Id)!.Value)
+                .OrderBy(id => id),
+        ];
+
+        Assert.NotEmpty(expected);
+        Assert.True(expected.Length < db.OrderRows.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    // Negative/empty: a structurally 3-level tree that is unsatisfiable by
+    // every row (no order total is ever outside +-100000), regardless of the
+    // second AND operand.
+    [Fact]
+    public void EachTreeThatIsUnsatisfiableForEveryRowReturnsEmptyResult()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachAndOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachOrOperator(
+                                [
+                                    new BooleanArrayReturning(
+                                        new EachComparison(
+                                            new EachNumberComparison(
+                                                EachComparisonOperator.EachGreaterThan,
+                                                new NumberArrayReturning(
+                                                    new NumberField(
+                                                        SampleDatabase.Orders.Entity,
+                                                        SampleDatabase.Orders.Total
+                                                    )
+                                                ),
+                                                new NumberReturning(
+                                                    new NumberScalar(100000)
+                                                )
+                                            )
+                                        )
+                                    ),
+                                    new BooleanArrayReturning(
+                                        new EachComparison(
+                                            new EachNumberComparison(
+                                                EachComparisonOperator.EachLessThan,
+                                                new NumberArrayReturning(
+                                                    new NumberField(
+                                                        SampleDatabase.Orders.Entity,
+                                                        SampleDatabase.Orders.Total
+                                                    )
+                                                ),
+                                                new NumberReturning(
+                                                    new NumberScalar(-100000)
+                                                )
+                                            )
+                                        )
+                                    ),
+                                ]
+                            )
+                        ),
+                        new BooleanArrayReturning(
+                            new EachEquality(
+                                new EachStringEquality(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Status
+                                        )
+                                    ),
+                                    new StringReturning(new StringScalar("shipped"))
+                                )
+                            )
+                        ),
+                    ]
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Negative/empty: a restrictive INNER JOIN that matches zero rows makes
+    // every downstream row disappear, even when the each* WHERE tree (however
+    // deeply nested) would otherwise evaluate true for every remaining row.
+    [Fact]
+    public void EachTreeOverRestrictiveJoinWithNoMatchesReturnsEmptyResult()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanArrayReturning(
+                new EachOrOperator(
+                    [
+                        new BooleanArrayReturning(
+                            new EachComparison(
+                                new EachNumberComparison(
+                                    EachComparisonOperator.EachGreaterThan,
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    ),
+                                    new NumberReturning(new NumberScalar(0))
+                                )
+                            )
+                        ),
+                        new BooleanArrayReturning(
+                            new EachEquality(
+                                new EachStringEquality(
+                                    new StringArrayReturning(
+                                        new StringField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Status
+                                        )
+                                    ),
+                                    new StringReturning(new StringScalar("nonexistent"))
+                                )
+                            )
+                        ),
+                    ]
+                )
+            ),
+            [
+                new Join(
+                    JoinType.Inner,
+                    SampleDatabase.Users.Entity,
+                    new BooleanArrayReturning(
+                        new EachComparison(
+                            new EachNumberComparison(
+                                EachComparisonOperator.EachGreaterThan,
+                                new NumberArrayReturning(
+                                    new NumberField(
+                                        SampleDatabase.Users.Entity,
+                                        SampleDatabase.Users.Age
+                                    )
+                                ),
+                                new NumberReturning(new NumberScalar(9999))
+                            )
+                        )
+                    )
+                ),
+            ],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the test batch scoped in #98 (part of #72), applying the corrections from the issue's follow-up comment.
- `NestedEachTests.cs`: `eachAnd`/`eachOr`/`eachNot` composition over `eachEquality`/`eachComparison`/`eachArithmetic` leaves at depth 2 through 5, mixed arithmetic+boolean nesting, each* over joined columns nested 3 levels deep, and empty/negative cases. The 5-level tree (`eachAnd(eachOr(eachNot(eachAnd(a,b)), c), eachOr(eachNot(d), eachAnd(e,f)))`) is verified row-by-row against a LINQ-equivalent per-row predicate, not just by count.
- `EachBroadcastAndLiteralTests.cs`: broadcast scalar + array-aligned field operand in one `eachAnd`, plus **real asserting tests** (not KnownGap skips) for `eachDivide`-by-zero→null and literal-array each* operands always broadcasting only their first element — both reclassified from originally-planned KnownGap items after the README audit confirmed they're deterministic, defined behavior.
- `ArrayEqualitySequenceTests.cs`: confirms whole-array `equal` between two literals is true `SequenceEqual` (2 passing tests), and pins the one genuine remaining gap in this issue's scope as `[Fact(Skip = "KnownGap: ...")]` — field-vs-literal whole-array equality evaluates as per-row `Enumerable.Contains` membership instead of sequence equality (epic #72 decision 7).

Closes #98

## Test plan
- [x] `dotnet build --no-restore -warnaserror` — clean
- [x] `dotnet test --no-build --verbosity normal` — 323 total, 319 passed, 4 skipped (3 pre-existing + 1 new KnownGap), 0 failed
- [x] `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)