### PR TITLE
Fix ProjectionResult column-order guarantee (test infra)

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/ProjectionResult.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/ProjectionResult.cs
@@ -12,6 +12,16 @@ internal sealed class ProjectionResult
 {
     public ProjectionResult(IStoredTableDataSet projection)
     {
+        // TableSchema.Columns is the ordered, authoritative source of output
+        // column order (see RowsFromDatasets/SelectColumns). row.Cells is a
+        // Pure.Collections.Generic.Dictionary that lazily materializes a
+        // FrozenDictionary for enumeration, whose key order is unspecified,
+        // so column order must be captured here rather than derived from it.
+        IReadOnlyList<string> columnOrder =
+        [
+            .. projection.TableSchema.Columns.Select(column => column.Name.TextValue),
+        ];
+
         List<ResultRow> rows = [];
 
         foreach (IRow row in projection)
@@ -23,7 +33,7 @@ internal sealed class ProjectionResult
                 cells[cell.Key.Name.TextValue] = cell.Value.Value.TextValue;
             }
 
-            rows.Add(new ResultRow(cells));
+            rows.Add(new ResultRow(cells, columnOrder));
         }
 
         Rows = rows;
@@ -47,11 +57,19 @@ internal sealed class ProjectionResult
     }
 }
 
-internal sealed class ResultRow(IReadOnlyDictionary<string, string?> cells)
+internal sealed class ResultRow(
+    IReadOnlyDictionary<string, string?> cells,
+    IReadOnlyList<string> columnOrder
+)
 {
     private readonly IReadOnlyDictionary<string, string?> _cells = cells;
 
-    public IEnumerable<string> ColumnNames => _cells.Keys;
+    private readonly IReadOnlyList<string> _columnOrder = columnOrder;
+
+    // Column order is authoritative from the caller (TableSchema.Columns),
+    // not the cell dictionary's own enumeration order, which is unspecified.
+    public IEnumerable<string> ColumnNames =>
+        _columnOrder.Where(_cells.ContainsKey);
 
     public bool Has(string column)
     {

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/SelectColumnOrderTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/SelectColumnOrderTests.cs
@@ -1,0 +1,126 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Fields;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Select;
+
+// Regression coverage for issue #107: ProjectionResult/ResultRow.ColumnNames
+// must reflect select-expression order, not the enumeration order of the
+// underlying row.Cells dictionary (which lazily materializes a
+// FrozenDictionary whose key order is unspecified). Selecting all seven typed
+// columns in an order deliberately different from both their declaration
+// order and their apparent hash order, and repeating the run many times,
+// would have exposed the bug if ColumnNames were derived from cell-map
+// enumeration instead of the query's select order.
+[Trait("Clause", "Select")]
+[Trait("Feature", "SelectColumnOrder")]
+public sealed class SelectColumnOrderTests
+{
+    [Fact]
+    public void SelectManyColumnsInShuffledOrderPreservesSelectExpressionOrder()
+    {
+        string[] expectedOrder =
+        [
+            SampleDatabase.Users.ShiftStart,
+            SampleDatabase.Users.Id,
+            SampleDatabase.Users.LastLogin,
+            SampleDatabase.Users.Name,
+            SampleDatabase.Users.SignupDate,
+            SampleDatabase.Users.Active,
+            SampleDatabase.Users.Age,
+        ];
+
+        for (int iteration = 0; iteration < 25; iteration++)
+        {
+            SampleDatabase db = new SampleDatabase();
+
+            Query query = new Query(
+                new FromExpression(SampleDatabase.Users.Entity),
+                [
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new TimeArrayReturning(
+                                new TimeField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.ShiftStart
+                                )
+                            )
+                        )
+                    ),
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.Id
+                                )
+                            )
+                        )
+                    ),
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new DateTimeArrayReturning(
+                                new DateTimeField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.LastLogin
+                                )
+                            )
+                        )
+                    ),
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new StringArrayReturning(
+                                new StringField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.Name
+                                )
+                            )
+                        )
+                    ),
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new DateArrayReturning(
+                                new DateField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.SignupDate
+                                )
+                            )
+                        )
+                    ),
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new BooleanArrayReturning(
+                                new BooleanField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.Active
+                                )
+                            )
+                        )
+                    ),
+                    new SelectExpression(
+                        new ArrayReturning(
+                            new NumberArrayReturning(
+                                new NumberField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.Age
+                                )
+                            )
+                        )
+                    ),
+                ]
+            );
+
+            ProjectionResult result = new ProjectionResult(
+                new PureQLProjection(db.Datasets, query)
+            );
+
+            Assert.Equal(expectedOrder, result.ColumnNames);
+
+            foreach (ResultRow row in result.Rows)
+            {
+                Assert.Equal(expectedOrder, row.ColumnNames);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #107

## Summary

- `ProjectionResult`/`ResultRow` (`src/Tests/.../Data/ProjectionResult.cs`) previously exposed `ColumnNames` from the `Dictionary<string, string?>` built by iterating `row.Cells`. The translator's concrete row cell map is a `Pure.Collections.Generic.Dictionary<TItem,TKey,TValue>`, which lazily materializes a `System.Collections.Frozen.FrozenDictionary` for enumeration — `FrozenDictionary` enumeration order is explicitly unspecified by .NET, so `ColumnNames` was relying on an implementation detail that happens to hold today, not a guarantee.
- Fix: `ProjectionResult` now captures column order from `projection.TableSchema.Columns` (an ordered list — the single source of truth used by `SelectColumns`/`RowsFromDatasets`) at construction time, and passes it to each `ResultRow`. `ResultRow.ColumnNames` filters that ordered list down to the columns present in the row instead of deriving order from the cell dictionary's `Keys`.
- No production library code changed (only test infrastructure under `src/Tests/.../Data/ProjectionResult.cs`).
- Added `Select/SelectColumnOrderTests.cs`: selects all seven typed columns of `Users` in an order shuffled away from both declaration order and select order, repeated across 25 runs, asserting `ProjectionResult.ColumnNames` and every `ResultRow.ColumnNames` match the select-expression order exactly. This would have caught the bug had `ColumnNames` still been keyed off `row.Cells` enumeration.
- Verified none of the existing tests that assert order via `.ColumnNames` (in `Select/SelectAliasTests.cs`, `Select/SelectAllTypesTests.cs`, `Select/SelectColumnsTests.cs`, `Select/ScalarProjectionTests.cs`, `Select/AliasCoverageTests.cs`, `Select/DistinctInteractionTests.cs`, `GroupBy/MixedProjectionTests.cs`, `Api/TableSchemaTests.cs`) needed any changes — the fix restores the guarantee at the shared infra level as intended.

## Test plan

- [x] `dotnet restore`
- [x] `dotnet build --no-restore -warnaserror`
- [x] `dotnet format --verify-no-changes`
- [x] `dotnet test --no-build --verbosity normal` — full suite green: 323 passed, 3 skipped (known gaps), 0 failed