### PR TITLE
Add three-valued-logic and NULL-cell test coverage (issue #103)

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/CellText.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/CellText.cs
@@ -19,6 +19,15 @@ internal static class CellText
         return value.ToString(CultureInfo.InvariantCulture);
     }
 
+    // A NULL cell is stored as empty text (the same convention
+    // JoinApplicator's EmptyCell uses for unmatched outer-join padding);
+    // CellValueExtractor's TryParse-based getters all fail on "" and yield
+    // null, so this round-trips through the whole pipeline as a real NULL.
+    internal static string From(double? value)
+    {
+        return value.HasValue ? From(value.Value) : string.Empty;
+    }
+
     internal static string From(string value)
     {
         return value;

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/SampleDatabase.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/SampleDatabase.cs
@@ -36,6 +36,13 @@ internal sealed class SampleDatabase
         public const string SignupDate = "signup_date";
         public const string LastLogin = "last_login";
         public const string ShiftStart = "shift_start";
+
+        // NULL-semantics fixture columns (issue #103): see SampleRecords.cs.
+        public const string Score = "user_score";
+        public const string PrecisionValue = "user_precision_value";
+        public const string EdgeDate = "user_edge_date";
+        public const string EdgeDateTime = "user_edge_datetime";
+        public const string EdgeTime = "user_edge_time";
     }
 
     public static class Orders
@@ -89,6 +96,11 @@ internal sealed class SampleDatabase
         new Column.Column(new String(Users.SignupDate), new DateColumnType()),
         new Column.Column(new String(Users.LastLogin), new DateTimeColumnType()),
         new Column.Column(new String(Users.ShiftStart), new TimeColumnType()),
+        new Column.Column(new String(Users.Score), new DoubleColumnType()),
+        new Column.Column(new String(Users.PrecisionValue), new DoubleColumnType()),
+        new Column.Column(new String(Users.EdgeDate), new DateColumnType()),
+        new Column.Column(new String(Users.EdgeDateTime), new DateTimeColumnType()),
+        new Column.Column(new String(Users.EdgeTime), new TimeColumnType()),
     ];
 
     private static readonly IReadOnlyList<IColumn> OrderColumns =
@@ -209,6 +221,10 @@ internal sealed class SampleDatabase
     public IEnumerable<IStoredSchemaDataSet> Datasets => _datasets;
 
     public IReadOnlyList<UserRow> UserRows { get; } = [
+        // Score is NULL for Bob and Dan (issue #103 NULL-semantics fixture):
+        // Ann/Cara/Fay's Score equals their own Age (so "age = score" is a
+        // real match), Eve's does not (a real mismatch, not NULL-caused), and
+        // Bob/Dan's NULL always drops out of equality/aggregate/group/sort.
         new(
             Id(1),
             "Ann",
@@ -216,7 +232,12 @@ internal sealed class SampleDatabase
             true,
             new DateOnly(2020, 1, 15),
             new DateTime(2024, 6, 1, 8, 30, 0),
-            new TimeOnly(9, 0, 0)
+            new TimeOnly(9, 0, 0),
+            30,
+            double.MaxValue,
+            new DateOnly(2024, 2, 29),
+            new DateTime(2024, 2, 29, 0, 0, 0),
+            new TimeOnly(0, 0, 0)
         ),
         new(
             Id(2),
@@ -225,7 +246,12 @@ internal sealed class SampleDatabase
             false,
             new DateOnly(2021, 3, 20),
             new DateTime(2024, 6, 2, 9, 15, 0),
-            new TimeOnly(10, 0, 0)
+            new TimeOnly(10, 0, 0),
+            null,
+            double.MinValue,
+            new DateOnly(2024, 12, 31),
+            new DateTime(2024, 12, 31, 23, 59, 59),
+            new TimeOnly(23, 59, 59)
         ),
         new(
             Id(3),
@@ -234,7 +260,12 @@ internal sealed class SampleDatabase
             true,
             new DateOnly(2019, 7, 10),
             new DateTime(2024, 5, 30, 14, 0, 0),
-            new TimeOnly(9, 0, 0)
+            new TimeOnly(9, 0, 0),
+            30,
+            double.Epsilon,
+            new DateOnly(2024, 3, 10),
+            new DateTime(2024, 3, 10, 2, 30, 0),
+            new TimeOnly(2, 30, 0)
         ),
         new(
             Id(4),
@@ -243,7 +274,12 @@ internal sealed class SampleDatabase
             true,
             new DateOnly(2022, 11, 5),
             new DateTime(2024, 6, 3, 18, 45, 0),
-            new TimeOnly(11, 30, 0)
+            new TimeOnly(11, 30, 0),
+            null,
+            -double.Epsilon,
+            new DateOnly(2024, 11, 3),
+            new DateTime(2024, 11, 3, 1, 30, 0),
+            new TimeOnly(1, 30, 0)
         ),
         new(
             Id(5),
@@ -252,7 +288,12 @@ internal sealed class SampleDatabase
             false,
             new DateOnly(2023, 2, 28),
             new DateTime(2024, 6, 4, 7, 5, 0),
-            new TimeOnly(8, 0, 0)
+            new TimeOnly(8, 0, 0),
+            10,
+            1e308,
+            new DateOnly(1, 1, 1),
+            new DateTime(1, 1, 1, 0, 0, 0),
+            new TimeOnly(0, 0, 0)
         ),
         // Shares SignupDate, LastLogin and ShiftStart with Ann, so those
         // columns are discriminating for DISTINCT tests over each type.
@@ -263,7 +304,12 @@ internal sealed class SampleDatabase
             true,
             new DateOnly(2020, 1, 15),
             new DateTime(2024, 6, 1, 8, 30, 0),
-            new TimeOnly(9, 0, 0)
+            new TimeOnly(9, 0, 0),
+            28,
+            123456789.123456,
+            new DateOnly(9999, 12, 31),
+            new DateTime(9999, 12, 31, 23, 59, 59),
+            new TimeOnly(23, 59, 59)
         ),
     ];
 
@@ -362,6 +408,11 @@ internal sealed class SampleDatabase
                         [Users.SignupDate] = CellText.From(user.SignupDate),
                         [Users.LastLogin] = CellText.From(user.LastLogin),
                         [Users.ShiftStart] = CellText.From(user.ShiftStart),
+                        [Users.Score] = CellText.From(user.Score),
+                        [Users.PrecisionValue] = CellText.From(user.PrecisionValue),
+                        [Users.EdgeDate] = CellText.From(user.EdgeDate),
+                        [Users.EdgeDateTime] = CellText.From(user.EdgeDateTime),
+                        [Users.EdgeTime] = CellText.From(user.EdgeTime),
                     }
                 )
             ),

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/SampleRecords.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/SampleRecords.cs
@@ -11,7 +11,16 @@ internal sealed record UserRow(
     bool UserActive,
     DateOnly SignupDate,
     DateTime LastLogin,
-    TimeOnly ShiftStart
+    TimeOnly ShiftStart,
+    // NULL-semantics fixture columns (issue #103): Score is NULL for two
+    // users (Bob, Dan) to exercise three-valued WHERE/GROUP BY/aggregate/
+    // DISTINCT/ORDER BY behavior; PrecisionValue and the Edge* triple hold
+    // numeric-extreme and calendar-edge values for round-trip coverage.
+    double? Score,
+    double PrecisionValue,
+    DateOnly EdgeDate,
+    DateTime EdgeDateTime,
+    TimeOnly EdgeTime
 );
 
 internal sealed record OrderRow(

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/UuidCasingDatabase.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Data/UuidCasingDatabase.cs
@@ -1,0 +1,97 @@
+using Pure.RelationalSchema.Abstractions.Column;
+using Pure.RelationalSchema.Abstractions.Schema;
+using Pure.RelationalSchema.Abstractions.Table;
+using Pure.RelationalSchema.ColumnType;
+using Pure.RelationalSchema.HashCodes;
+using Pure.RelationalSchema.Storage.Abstractions;
+using String = Pure.Primitives.String.String;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+
+// A minimal one-table dataset built by hand (not through SampleDatabase,
+// which always formats stored UUID text lowercase via Guid.ToString()) so
+// the stored cell text of two logically-identical UUIDs differs only in
+// hex casing (issue #103: "UUID casing round-trips to the same logical
+// value in equality/comparison").
+internal sealed class UuidCasingDatabase
+{
+    public const string SchemaName = "casing";
+
+    public static class Things
+    {
+        public const string TableName = "things";
+        public const string Entity = "casing.things";
+        public const string Id = "thing_id";
+        public const string Label = "thing_label";
+    }
+
+    // The same logical Guid stored once with lowercase hex text and once
+    // with uppercase hex text.
+    public static readonly Guid SharedId = new Guid(
+        "0f9e8d7c-6b5a-4938-8271-605f4e3d2c1b"
+    );
+
+    private static readonly IReadOnlyList<IColumn> ThingColumns =
+    [
+        new Column.Column(new String(Things.Id), new UuidColumnType()),
+        new Column.Column(new String(Things.Label), new StringColumnType()),
+    ];
+
+    private readonly IReadOnlyList<IStoredSchemaDataSet> _datasets;
+
+    public UuidCasingDatabase()
+    {
+        ITable thingsTable = new Table.Table(
+            new String(Things.TableName),
+            ThingColumns,
+            []
+        );
+
+        ISchema schema = new Schema.Schema(
+            new String(SchemaName),
+            [thingsTable],
+            []
+        );
+
+        IReadOnlyDictionary<ITable, IStoredTableDataSet> datasetsByTable =
+            new Collections.Generic.Dictionary<
+                IStoredTableDataSet,
+                ITable,
+                IStoredTableDataSet
+            >(
+                [new SampleTableDataset(thingsTable, BuildThingRows())],
+                dataset => dataset.TableSchema,
+                dataset => dataset,
+                table => new TableHash(table)
+            );
+
+        _datasets = [new StoredSchemaDataset(schema, datasetsByTable)];
+    }
+
+    public IEnumerable<IStoredSchemaDataSet> Datasets => _datasets;
+
+    private static IReadOnlyList<IRow> BuildThingRows()
+    {
+        return
+        [
+            BuildRow(SharedId.ToString().ToLowerInvariant(), "lowercase"),
+            BuildRow(SharedId.ToString().ToUpperInvariant(), "uppercase"),
+        ];
+    }
+
+    private static IRow BuildRow(string idText, string label)
+    {
+        return new Row(
+            new Collections.Generic.Dictionary<IColumn, IColumn, ICell>(
+                ThingColumns,
+                column => column,
+                column => new Cell(
+                    new String(
+                        column.Name.TextValue == Things.Id ? idText : label
+                    )
+                ),
+                column => new ColumnHash(column)
+            )
+        );
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Types/NullSemanticsTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Types/NullSemanticsTests.cs
@@ -1,0 +1,721 @@
+using System.Globalization;
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayEqualities;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Types;
+
+// Three-valued (NULL) semantics across every clause: a NULL cell is stored as
+// empty text (SampleDatabase.Users.Score, NULL for Bob and Dan; see
+// SampleRecords.cs and CellText.From(double?)). This suite pins how the
+// translator actually treats NULL today in WHERE, each*, GROUP BY, aggregates,
+// DISTINCT and ORDER BY, plus separate coverage for numeric-extreme,
+// calendar-edge and UUID-casing round-trips (SampleDatabase.Users
+// PrecisionValue/EdgeDate/EdgeDateTime/EdgeTime columns).
+[Trait("Clause", "Types")]
+[Trait("Feature", "NullSemantics")]
+public sealed class NullSemanticsTests
+{
+    // WHERE user_age = user_score (Equality -> ArrayEquality -> field vs
+    // field, evaluated per row): this is the only way a non-each ("scalar"
+    // family, BooleanReturning) predicate can reference a row's cells at all
+    // - see WhereExpressionBuilder.BuildContainmentEquality's left&&right
+    // branch. Ann/Cara/Fay's Score equals their own Age (real matches);
+    // Eve's does not (a real mismatch); Bob/Dan's Score is NULL, so the
+    // comparison is SQL's three-valued "unknown", not true - those rows must
+    // be excluded exactly like Eve's real mismatch, never kept.
+    [Fact]
+    public void ScalarFieldEqualityExcludesRowsWhoseComparedCellIsNull()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new NumberArrayEquality(
+                            new NumberArrayReturning(
+                                new NumberField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.Age
+                                )
+                            ),
+                            new NumberArrayReturning(
+                                new NumberField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.Score
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.UserRows
+                .Where(user => user.Score == user.UserAge)
+                .Select(user => user.UserName)
+                .OrderBy(name => name, StringComparer.Ordinal),
+        ];
+
+        Assert.Equal(["Ann", "Cara", "Fay"], expected);
+        Assert.Equal(
+            expected,
+            result.Column(SampleDatabase.Users.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray()
+        );
+    }
+
+    // WHERE each user_score = 30 (per-row eachEqual against a literal): a
+    // NULL Score cell must drop the row from the result, not error and not
+    // be silently treated as a false-negative match. Bob and Dan (both
+    // NULL) are excluded for the same reason Eve (Score = 10) is - the
+    // comparison never becomes true.
+    [Fact]
+    public void EachEqualityExcludesRowsWhoseFieldCellIsNull()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachNumberEquality(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Score
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(30))
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.UserRows
+                .Where(user => user.Score == 30)
+                .Select(user => user.UserName)
+                .OrderBy(name => name, StringComparer.Ordinal),
+        ];
+
+        Assert.Equal(["Ann", "Cara"], expected);
+        Assert.Equal(
+            expected,
+            result.Column(SampleDatabase.Users.Name)
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToArray()
+        );
+    }
+
+    // GROUP BY user_score: SQL groups all NULL keys into a single group
+    // (distinct from every non-NULL group). GroupByApplicator.BuildGroupKey
+    // maps a NULL cell to string.Empty for every field type, so Bob and Dan
+    // (both NULL) land in the same group. Count(Users.Id) - never NULL -
+    // confirms that group holds exactly the two of them.
+    [Fact]
+    public void GroupByNullKeyCollapsesAllNullRowsIntoOneGroup()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Score
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Users.Entity,
+                                            SampleDatabase.Users.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "n"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new NumberField(
+                        SampleDatabase.Users.Entity,
+                        SampleDatabase.Users.Score
+                    )
+                ),
+            ],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedGroupCount = db.UserRows
+            .Select(user => user.Score)
+            .Distinct()
+            .Count();
+
+        Assert.Equal(4, expectedGroupCount);
+        Assert.Equal(expectedGroupCount, result.Count);
+
+        ResultRow nullGroup = Assert.Single(
+            result.Rows,
+            row => row[SampleDatabase.Users.Score] == string.Empty
+        );
+        Assert.Equal(2.0, nullGroup.Double("n"));
+    }
+
+    // sum/avg/min/max over user_score: SQL-standard aggregates ignore NULL
+    // cells rather than letting them poison the fold (AggregateEvaluator.Fold
+    // filters with `.OfType<T>()`, dropping the two NULLs from Bob and Dan).
+    [Fact]
+    public void NumericAggregatesIgnoreNullCellsWhenFoldingTheWholeSet()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        double[] nonNullScores =
+        [
+            .. db.UserRows.Select(user => user.Score).OfType<double>(),
+        ];
+
+        Assert.Equal(4, nonNullScores.Length);
+
+        Query SumAvgMinMaxQuery(string aggregateAlias, SelectExpression expression)
+        {
+            return new Query(
+                new FromExpression(SampleDatabase.Users.Entity),
+                [expression]
+            );
+        }
+
+        SelectExpression SelectOf(NumberAggregate aggregate, string alias)
+        {
+            return new SelectExpression(
+                new SingleValueReturning(new NumberReturning(aggregate)),
+                alias
+            );
+        }
+
+        NumberArrayReturning scoreField = new NumberArrayReturning(
+            new NumberField(SampleDatabase.Users.Entity, SampleDatabase.Users.Score)
+        );
+
+        ProjectionResult sumResult = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                SumAvgMinMaxQuery(
+                    "sum_score",
+                    SelectOf(new NumberAggregate(new SumNumber(scoreField)), "sum_score")
+                )
+            )
+        );
+        ProjectionResult avgResult = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                SumAvgMinMaxQuery(
+                    "avg_score",
+                    SelectOf(new NumberAggregate(new AverageNumber(scoreField)), "avg_score")
+                )
+            )
+        );
+        ProjectionResult minResult = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                SumAvgMinMaxQuery(
+                    "min_score",
+                    SelectOf(new NumberAggregate(new MinNumber(scoreField)), "min_score")
+                )
+            )
+        );
+        ProjectionResult maxResult = new ProjectionResult(
+            new PureQLProjection(
+                db.Datasets,
+                SumAvgMinMaxQuery(
+                    "max_score",
+                    SelectOf(new NumberAggregate(new MaxNumber(scoreField)), "max_score")
+                )
+            )
+        );
+
+        Assert.Equal(nonNullScores.Sum(), sumResult.Row(0).Double("sum_score"));
+        Assert.Equal(nonNullScores.Average(), avgResult.Row(0).Double("avg_score"));
+        Assert.Equal(nonNullScores.Min(), minResult.Row(0).Double("min_score"));
+        Assert.Equal(nonNullScores.Max(), maxResult.Row(0).Double("max_score"));
+    }
+
+    // SELECT DISTINCT user_score: SQL treats every NULL as equal to every
+    // other NULL for dedup purposes, so Bob and Dan's two NULL rows collapse
+    // into a single output row (DistinctApplicator.BuildKey renders a NULL
+    // cell's text as "" for every row, giving both the same dedup key).
+    [Fact]
+    public void DistinctCollapsesMultipleNullRowsIntoOne()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Score
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        int expectedDistinctCount = db.UserRows
+            .Select(user => user.Score)
+            .Distinct()
+            .Count();
+
+        Assert.Equal(4, expectedDistinctCount);
+        Assert.Equal(expectedDistinctCount, result.Count);
+        _ = Assert.Single(
+            result.Rows,
+            row => row[SampleDatabase.Users.Score] == string.Empty
+        );
+    }
+
+    // ORDER BY user_score ASC/DESC: pins today's actual behavior rather than
+    // asserting a SQL-standard NULLS FIRST/LAST rule (the spec leaves the
+    // ordering of NULLs relative to values engine-defined, and this library
+    // simply delegates to .NET's default nullable comparer via
+    // IQueryable.OrderBy/OrderByDescending on double?, where null sorts as
+    // the smallest possible value). The expected sequence below is produced
+    // by the identical LINQ ordering over the ground-truth records, so a
+    // change to this behavior will show up here rather than only in
+    // production.
+    [Fact]
+    public void OrderByAscendingPlacesNullScoreCellsFirst()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new NumberField(
+                            SampleDatabase.Users.Entity,
+                            SampleDatabase.Users.Score
+                        )
+                    ),
+                    SortDirection.Asc
+                ),
+            ],
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.UserRows.OrderBy(user => user.Score).Select(user => user.UserName),
+        ];
+
+        Assert.Equal(["Bob", "Dan"], expected[..2]);
+        Assert.Equal(expected, result.Column(SampleDatabase.Users.Name).ToArray());
+    }
+
+    [Fact]
+    public void OrderByDescendingPlacesNullScoreCellsLast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new NumberField(
+                            SampleDatabase.Users.Entity,
+                            SampleDatabase.Users.Score
+                        )
+                    ),
+                    SortDirection.Desc
+                ),
+            ],
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.UserRows
+                .OrderByDescending(user => user.Score)
+                .Select(user => user.UserName),
+        ];
+
+        Assert.Equal(["Bob", "Dan"], expected[^2..]);
+        Assert.Equal(expected, result.Column(SampleDatabase.Users.Name).ToArray());
+    }
+
+    // Numeric precision/extremes: double.MaxValue/MinValue, the smallest
+    // representable positive/negative subnormal (double.Epsilon), a value
+    // near the exponent limit (1e308) and a value with many significant
+    // digits that would suffer rounding if formatted with anything less
+    // than a round-trippable format. CellText.From(double) uses plain
+    // ToString(InvariantCulture) - round-trippable by default since
+    // .NET Core 3.0 - and CellValueExtractor.GetDoubleValue parses it back
+    // with the same invariant culture, so every value below must survive
+    // the storage-text round trip exactly.
+    [Fact]
+    public void ExtremeAndPrecisionSensitiveDoublesRoundTripExactly()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.PrecisionValue
+                            )
+                        )
+                    )
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(
+            [.. db.UserRows.Select(user => (double?)user.PrecisionValue)],
+            [.. result.Rows.Select(row => row.Double(SampleDatabase.Users.PrecisionValue))]
+        );
+        Assert.Contains(double.MaxValue, db.UserRows.Select(user => user.PrecisionValue));
+        Assert.Contains(double.MinValue, db.UserRows.Select(user => user.PrecisionValue));
+        Assert.Contains(
+            double.Epsilon,
+            db.UserRows.Select(user => user.PrecisionValue)
+        );
+    }
+
+    // Date/DateTime/Time edge-value round trips: midnight and end-of-day
+    // times, a leap-year date (2024-02-29), and two DST-adjacent-looking
+    // instants (2024-03-10 02:30 / 2024-11-03 01:30 - the US spring-forward
+    // gap and fall-back-ambiguous hour). The library's model is UTC/
+    // offset-naive, so nothing here should be affected by DST at all - that
+    // is exactly what this test confirms by round-tripping the raw values
+    // with no timezone conversion applied anywhere in the pipeline.
+    [Fact]
+    public void CalendarEdgeValuesRoundTripAcrossDateDateTimeAndTime()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new DateArrayReturning(
+                            new DateField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.EdgeDate
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new DateTimeArrayReturning(
+                            new DateTimeField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.EdgeDateTime
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new TimeArrayReturning(
+                            new TimeField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.EdgeTime
+                            )
+                        )
+                    )
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(
+            [.. db.UserRows.Select(user => (DateOnly?)user.EdgeDate)],
+            [.. result.Rows.Select(row => row.Date(SampleDatabase.Users.EdgeDate))]
+        );
+        Assert.Equal(
+            [.. db.UserRows.Select(user => (DateTime?)user.EdgeDateTime)],
+            [.. result.Rows.Select(row => row.DateTime(SampleDatabase.Users.EdgeDateTime))]
+        );
+        Assert.Equal(
+            [.. db.UserRows.Select(user => (TimeOnly?)user.EdgeTime)],
+            [.. result.Rows.Select(row => row.Time(SampleDatabase.Users.EdgeTime))]
+        );
+        Assert.Contains(
+            new DateOnly(2024, 2, 29),
+            db.UserRows.Select(user => user.EdgeDate)
+        );
+        Assert.Contains(new TimeOnly(0, 0, 0), db.UserRows.Select(user => user.EdgeTime));
+        Assert.Contains(
+            new TimeOnly(23, 59, 59),
+            db.UserRows.Select(user => user.EdgeTime)
+        );
+    }
+
+    // Confirms the round trip above has no ambient-locale dependency: run
+    // the same query with the current thread's culture switched to one
+    // whose date/number formatting differs sharply from invariant (comma
+    // decimal separator, day-first dates) and assert identical results.
+    // CellText/CellValueExtractor both fix CultureInfo.InvariantCulture
+    // explicitly, so ambient culture must have no effect.
+    [Fact]
+    public void CalendarAndNumericRoundTripsAreUnaffectedByAmbientCulture()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new DateTimeArrayReturning(
+                            new DateTimeField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.EdgeDateTime
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.PrecisionValue
+                            )
+                        )
+                    )
+                ),
+            ]
+        );
+
+        CultureInfo original = CultureInfo.CurrentCulture;
+        ProjectionResult result;
+
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            result = new ProjectionResult(new PureQLProjection(db.Datasets, query));
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = original;
+        }
+
+        Assert.Equal(
+            [.. db.UserRows.Select(user => (DateTime?)user.EdgeDateTime)],
+            [.. result.Rows.Select(row => row.DateTime(SampleDatabase.Users.EdgeDateTime))]
+        );
+        Assert.Equal(
+            [.. db.UserRows.Select(user => (double?)user.PrecisionValue)],
+            [.. result.Rows.Select(row => row.Double(SampleDatabase.Users.PrecisionValue))]
+        );
+    }
+
+    // UUID casing: a stored cell text in uppercase hex must parse to the
+    // same logical Guid as the equivalent lowercase text, and the two must
+    // compare equal under the translator's own field-vs-field equality path
+    // (Guid.TryParse is case-insensitive; CellValueExtractor.GetGuidValue
+    // relies on exactly that). A tiny bespoke one-table dataset is built
+    // here (not through SampleDatabase, which always formats UUIDs
+    // lowercase via Guid.ToString()) so the stored text itself differs only
+    // in casing between the two rows.
+    [Fact]
+    public void UppercaseAndLowercaseUuidTextCompareEqual()
+    {
+        UuidCasingDatabase db = new UuidCasingDatabase();
+
+        Query query = new Query(
+            new FromExpression(UuidCasingDatabase.Things.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                UuidCasingDatabase.Things.Entity,
+                                UuidCasingDatabase.Things.Label
+                            )
+                        )
+                    )
+                ),
+            ],
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                UuidCasingDatabase.Things.Entity,
+                                UuidCasingDatabase.Things.Id
+                            )
+                        ),
+                        new UuidReturning(new UuidScalar(UuidCasingDatabase.SharedId))
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string?[] expectedLabels = ["lowercase", "uppercase"];
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(
+            expectedLabels,
+            result.Column(UuidCasingDatabase.Things.Label)
+                .OrderBy(label => label, StringComparer.Ordinal)
+                .ToArray()
+        );
+    }
+}


### PR DESCRIPTION
Closes #103

## Summary
- Adds `Types/NullSemanticsTests.cs` covering the 🟡 three-valued-logic matrix from the #72 roadmap: NULL cells in scalar (field-vs-field `ArrayEquality`) and `each*` WHERE predicates are excluded (never falsely true/false), GROUP BY collapses all NULL-key rows into one group, `sum`/`avg`/`min`/`max` skip NULL cells rather than being poisoned by them, DISTINCT treats NULLs as equal for dedup, and ORDER BY's current NULL-placement behavior is pinned with an explanatory comment (not asserted as SQL-standard, since that's engine-defined).
- Also adds numeric precision/extreme-value round-trip coverage (`double.MaxValue`/`MinValue`/`Epsilon`, high-precision values), calendar-edge round-trip coverage (midnight, end-of-day, leap-year date, DST-adjacent-looking instants — confirmed unaffected by ambient culture), and a UUID hex-casing equality test (uppercase vs. lowercase stored text compare equal).
- Extends `Data/SampleDatabase.cs`'s Users table with a nullable `Score` column (NULL for two users) plus `PrecisionValue`/`EdgeDate`/`EdgeDateTime`/`EdgeTime` columns (additive only — verified the full pre-existing suite still passes unchanged). Adds a small standalone `Data/UuidCasingDatabase.cs` for the casing test, since `SampleDatabase` always formats UUIDs lowercase.
- Every bullet in the issue turned out to have real, defined (if in places engine-specific) behavior, so all 11 new tests are real assertions — none needed a `[Fact(Skip=...)]` KnownGap.

## Test plan
- [x] `dotnet restore`
- [x] `dotnet build --no-restore -warnaserror`
- [x] `dotnet format --verify-no-changes`
- [x] `dotnet test --no-build --verbosity normal` — full suite: 336 total, 333 passed, 3 skipped (unchanged pre-existing skips), 0 failed