### PR TITLE
Fail fast on missing columns, type mismatches, malformed cell text, and eachDivide by zero

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/CellValueExtractor.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/CellValueExtractor.cs
@@ -47,32 +47,46 @@ internal static class CellValueExtractor
             );
     }
 
+    // Field resolution (a nonexistent column) and cell-text parsing (a
+    // malformed or type-mismatched value) are different failure modes and
+    // must not be conflated: an unresolved field always fails fast via
+    // GetRequiredCell below, while an empty cell text is the sentinel for
+    // SQL NULL and stays a silent null - only genuinely unparseable,
+    // non-empty text throws.
     internal static string? GetTextValue(IRow row, string entity, string fieldName)
     {
-        return GetCell(row, entity, fieldName)?.Value.TextValue;
+        return GetRequiredCell(row, entity, fieldName).Value.TextValue;
     }
 
     internal static double? GetDoubleValue(IRow row, string entity, string fieldName)
     {
         string? text = GetTextValue(row, entity, fieldName);
 
-        return
-            text is not null
-            && double.TryParse(
+        return text is null || text.Length == 0
+            ? null
+            : double.TryParse(
                 text,
                 NumberStyles.Any,
                 CultureInfo.InvariantCulture,
                 out double v
             )
             ? v
-            : null;
+            : throw new FormatException(
+            $"Cell text '{text}' for field '{fieldName}' is not a valid number."
+        );
     }
 
     internal static bool? GetBoolValue(IRow row, string entity, string fieldName)
     {
         string? text = GetTextValue(row, entity, fieldName);
 
-        return text is not null && bool.TryParse(text, out bool v) ? v : null;
+        return text is null || text.Length == 0
+            ? null
+            : bool.TryParse(text, out bool v)
+            ? v
+            : throw new FormatException(
+            $"Cell text '{text}' for field '{fieldName}' is not a valid boolean."
+        );
     }
 
     internal static DateOnly? GetDateOnlyValue(
@@ -83,7 +97,13 @@ internal static class CellValueExtractor
     {
         string? text = GetTextValue(row, entity, fieldName);
 
-        return text is not null && DateOnly.TryParse(text, out DateOnly v) ? v : null;
+        return text is null || text.Length == 0
+            ? null
+            : DateOnly.TryParse(text, out DateOnly v)
+            ? (DateOnly?)v
+            : throw new FormatException(
+            $"Cell text '{text}' for field '{fieldName}' is not a valid date."
+        );
     }
 
     internal static DateTime? GetDateTimeValue(
@@ -94,16 +114,18 @@ internal static class CellValueExtractor
     {
         string? text = GetTextValue(row, entity, fieldName);
 
-        return
-            text is not null
-            && DateTime.TryParse(
+        return text is null || text.Length == 0
+            ? null
+            : DateTime.TryParse(
                 text,
                 CultureInfo.InvariantCulture,
                 DateTimeStyles.None,
                 out DateTime v
             )
-            ? v
-            : null;
+            ? (DateTime?)v
+            : throw new FormatException(
+            $"Cell text '{text}' for field '{fieldName}' is not a valid datetime."
+        );
     }
 
     internal static TimeOnly? GetTimeOnlyValue(
@@ -114,13 +136,25 @@ internal static class CellValueExtractor
     {
         string? text = GetTextValue(row, entity, fieldName);
 
-        return text is not null && TimeOnly.TryParse(text, out TimeOnly v) ? v : null;
+        return text is null || text.Length == 0
+            ? null
+            : TimeOnly.TryParse(text, out TimeOnly v)
+            ? (TimeOnly?)v
+            : throw new FormatException(
+            $"Cell text '{text}' for field '{fieldName}' is not a valid time."
+        );
     }
 
     internal static Guid? GetGuidValue(IRow row, string entity, string fieldName)
     {
         string? text = GetTextValue(row, entity, fieldName);
 
-        return text is not null && Guid.TryParse(text, out Guid v) ? v : null;
+        return text is null || text.Length == 0
+            ? null
+            : Guid.TryParse(text, out Guid v)
+            ? (Guid?)v
+            : throw new FormatException(
+            $"Cell text '{text}' for field '{fieldName}' is not a valid uuid."
+        );
     }
 }

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/WhereExpressionBuilder.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/WhereExpressionBuilder.cs
@@ -884,7 +884,14 @@ internal static class WhereExpressionBuilder
 
     internal static double? DivideDoubles(double? a, double? b)
     {
-        return a.HasValue && b.HasValue && b.Value != 0 ? a.Value / b.Value : null;
+        return !a.HasValue || !b.HasValue
+            ? null
+            : b.Value == 0
+            ? throw new DivideByZeroException(
+                "eachDivide by zero: division by zero is a defined failure, "
+                    + "matching SQL division-by-zero semantics."
+            )
+            : a.Value / b.Value;
     }
 
     private static Expression NullableDoubleAdd(Expression a, Expression b)

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Errors/NegativePathTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Errors/NegativePathTests.cs
@@ -20,12 +20,11 @@ using String = Pure.Primitives.String.String;
 namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Errors;
 
 // Part of the #72 roadmap (issue #104): dedicated negative-path coverage.
-// Every construct below is a defined failure or a documented KnownGap, never
-// a silent wrong answer, per the epic's stated principle. Tests that pin
-// today's actual (correct) fail-fast behaviour run normally; tests that
-// would need to fail fast but currently produce a silently wrong result
-// instead are skipped with [Fact(Skip = "KnownGap: ...")], pinning the
-// exception that *should* be thrown once the gap is closed.
+// Every construct below is a defined failure, never a silent wrong answer,
+// per the epic's stated principle (see issue #104's follow-up fix: the
+// CellValueExtractor getters and WhereExpressionBuilder.DivideDoubles now
+// throw on an unresolved field, a type-mismatched/malformed cell text, or a
+// zero divisor, instead of silently returning null).
 [Trait("Feature", "Negative")]
 public sealed class NegativePathTests
 {
@@ -285,24 +284,16 @@ public sealed class NegativePathTests
         _ = Assert.Throws<NotSupportedException>(() => new PureQLProjection(db.Datasets, query));
     }
 
-    // ===== KnownGap: missing column outside SELECT is silently absorbed =====
+    // ===== Missing column outside SELECT fails fast =====
 
-    // Unlike the required SELECT path (CellValueExtractor.GetRequiredCell),
-    // WHERE field resolution goes through CellValueExtractor.GetCell, which
-    // returns null when no column matches instead of throwing. A nonexistent
-    // column referenced in WHERE therefore silently compares as "no match"
-    // for every row (0 results) instead of failing fast the way the same
-    // typo would in SELECT. Pinning the SELECT path's KeyNotFoundException as
-    // the spec-correct expectation.
-    [Fact(
-        Skip = "KnownGap: CellValueExtractor.GetCell returns null for an "
-            + "unresolved column instead of throwing, so a nonexistent "
-            + "column in WHERE silently excludes every row rather than "
-            + "failing fast the way the same typo does in SELECT."
-    )]
-    [Trait("Status", "KnownGap")]
+    // WHERE field resolution goes through CellValueExtractor.GetTextValue,
+    // which now requires the cell (GetRequiredCell) the same way the SELECT
+    // path always did, so a nonexistent column referenced in WHERE throws
+    // the same KeyNotFoundException a typo would in SELECT instead of
+    // silently excluding every row.
+    [Fact]
     [Trait("Clause", "Where")]
-    public void WhereFieldNotOnResolvedTableSilentlyExcludesRowsInsteadOfFailing()
+    public void WhereFieldNotOnResolvedTableFailsFast()
     {
         SampleDatabase db = new SampleDatabase();
 
@@ -345,26 +336,18 @@ public sealed class NegativePathTests
         ));
     }
 
-    // ===== KnownGap: type mismatch is silently absorbed, not rejected =====
+    // ===== Type mismatch fails fast =====
 
     // A NumberField pointing at order_status (a StringColumnType column) is
     // legal to construct - Field references are untyped strings, not checked
     // against the schema's declared column type. CellValueExtractor.
-    // GetDoubleValue parses the cell's text with double.TryParse; for a
-    // string column's text ("shipped", ...) that always fails and yields
-    // null, so every per-row numeric comparison against it is silently
-    // false instead of failing. Pinning FormatException (what a non-Try
-    // double.Parse on the same malformed text would throw) as the
-    // spec-correct expectation.
-    [Fact(
-        Skip = "KnownGap: CellValueExtractor.GetDoubleValue silently returns "
-            + "null for text that cannot parse as a number (e.g. a "
-            + "NumberField pointing at a string column), so the mismatched "
-            + "comparison silently excludes every row instead of failing."
-    )]
-    [Trait("Status", "KnownGap")]
+    // GetDoubleValue now throws FormatException for non-empty text that
+    // cannot parse as a number (e.g. a string column's "shipped"), instead
+    // of silently returning null and excluding every row from the
+    // comparison.
+    [Fact]
     [Trait("Clause", "Where")]
-    public void TypeMismatchNumberFieldAgainstStringColumnSilentlyExcludesRows()
+    public void TypeMismatchNumberFieldAgainstStringColumnFailsFast()
     {
         SampleDatabase db = new SampleDatabase();
 
@@ -408,23 +391,16 @@ public sealed class NegativePathTests
         ));
     }
 
-    // ===== KnownGap: malformed cell text is silently absorbed =====
+    // ===== Malformed cell text fails fast =====
 
     // A stored uuid cell whose text is not a valid Guid (corrupted/foreign
     // data, as opposed to a schema/reference type mismatch) is parsed by
-    // CellValueExtractor.GetGuidValue via Guid.TryParse, which likewise
-    // yields null on failure instead of surfacing the malformed text.
-    // Pinning FormatException (what Guid.Parse would throw on the same
-    // text) as the spec-correct expectation.
-    [Fact(
-        Skip = "KnownGap: CellValueExtractor.GetGuidValue silently returns "
-            + "null for a cell whose stored text is not a valid uuid, so a "
-            + "malformed cell is treated as an absent value instead of "
-            + "failing fast."
-    )]
-    [Trait("Status", "KnownGap")]
+    // CellValueExtractor.GetGuidValue via Guid.TryParse; non-empty text that
+    // fails to parse now throws FormatException instead of being treated as
+    // an absent value.
+    [Fact]
     [Trait("Clause", "Where")]
-    public void MalformedUuidCellTextSilentlyTreatedAsAbsentValue()
+    public void MalformedUuidCellTextFailsFast()
     {
         ITable table = new Table.Table(
             new String("widgets"),
@@ -492,22 +468,15 @@ public sealed class NegativePathTests
         ));
     }
 
-    // ===== KnownGap: eachDivide by zero is silently absorbed =====
+    // ===== eachDivide by zero fails fast =====
 
-    // WhereExpressionBuilder.DivideDoubles returns null when the divisor is
-    // zero instead of raising, so a row whose divisor is zero silently drops
-    // out of the predicate (never matches) instead of the query failing the
-    // way SQL division-by-zero does. Pinning DivideByZeroException as the
-    // spec-correct expectation.
-    [Fact(
-        Skip = "KnownGap: WhereExpressionBuilder.DivideDoubles returns null "
-            + "for a zero divisor instead of raising, so eachDivide by zero "
-            + "silently excludes the row instead of failing the way SQL "
-            + "division-by-zero does."
-    )]
-    [Trait("Status", "KnownGap")]
+    // WhereExpressionBuilder.DivideDoubles now raises DivideByZeroException
+    // for a zero divisor instead of returning null, so eachDivide by zero
+    // fails the query the way SQL division-by-zero does instead of silently
+    // excluding the row.
+    [Fact]
     [Trait("Clause", "Where")]
-    public void EachDivideByZeroSilentlyExcludesRowInsteadOfFailing()
+    public void EachDivideByZeroFailsFast()
     {
         SampleDatabase db = new SampleDatabase();
 
@@ -560,22 +529,15 @@ public sealed class NegativePathTests
         ));
     }
 
-    // ===== KnownGap: missing column in ORDER BY is silently absorbed =====
+    // ===== Missing column in ORDER BY fails fast =====
 
-    // OrderByApplicator sorts by CellValueExtractor.GetTextValue directly (no
-    // GetRequiredCell), so a nonexistent ORDER BY field silently sorts every
-    // row as null (a stable no-op order) instead of failing fast the way the
-    // same typo does in SELECT.
-    [Fact(
-        Skip = "KnownGap: OrderByApplicator resolves fields via "
-            + "CellValueExtractor's null-returning getters, so a "
-            + "nonexistent ORDER BY column silently orders every row as "
-            + "null instead of failing fast the way the same typo does in "
-            + "SELECT."
-    )]
-    [Trait("Status", "KnownGap")]
+    // OrderByApplicator resolves fields via CellValueExtractor's getters,
+    // which now require the cell to exist, so a nonexistent ORDER BY column
+    // throws the same KeyNotFoundException a typo would in SELECT instead
+    // of silently sorting every row as null.
+    [Fact]
     [Trait("Clause", "OrderBy")]
-    public void OrderByFieldNotOnResolvedTableSilentlyOrdersAsNull()
+    public void OrderByFieldNotOnResolvedTableFailsFast()
     {
         SampleDatabase db = new SampleDatabase();
 

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/EachBroadcastAndLiteralTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/EachBroadcastAndLiteralTests.cs
@@ -17,9 +17,9 @@ namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
 // array operand is never zipped by row index - every per-row evaluation
 // uses only the literal's first element (`.FirstOrDefault()`), broadcast to
 // every row regardless of the literal's declared length; and eachDivide by
-// zero returns null for that row rather than throwing. Also covers mixing a
-// scalar-broadcast operand with a per-row array-aligned operand within the
-// same predicate.
+// zero raises DivideByZeroException (see issue #104's follow-up fix) rather
+// than silently yielding null. Also covers mixing a scalar-broadcast operand
+// with a per-row array-aligned operand within the same predicate.
 [Trait("Clause", "Where")]
 [Trait("Feature", "EachBroadcastAndLiteral")]
 public sealed class EachBroadcastAndLiteralTests

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/EachBroadcastAndLiteralTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/EachBroadcastAndLiteralTests.cs
@@ -197,12 +197,12 @@ public sealed class EachBroadcastAndLiteralTests
         );
     }
 
-    // eachDivide by zero yields null for that row (DivideDoubles), and null
-    // never compares equal to a finite literal - it does not throw, and the
-    // equality check is false for every row (no exception propagates out of
-    // PureQLProjection construction or enumeration).
+    // eachDivide by zero raises DivideByZeroException (matching SQL
+    // division-by-zero semantics) as soon as any row's division is
+    // evaluated - it does not silently yield null, whether the divide
+    // result feeds an equality check, ...
     [Fact]
-    public void EachDivideByZeroYieldsNullNeverEqualToAFiniteLiteral()
+    public void EachDivideByZeroFailsFastEvenUnderEqualityComparison()
     {
         SampleDatabase db = new SampleDatabase();
 
@@ -238,18 +238,14 @@ public sealed class EachBroadcastAndLiteralTests
             pagination: null
         );
 
-        ProjectionResult result = new ProjectionResult(
+        _ = Assert.Throws<DivideByZeroException>(() => new ProjectionResult(
             new PureQLProjection(db.Datasets, query)
-        );
-
-        Assert.Equal(0, result.Count);
+        ));
     }
 
-    // Same eachDivide-by-zero result compared with a per-row comparison
-    // instead of equality: a lifted-nullable GreaterThan against null is
-    // false, never a thrown DivideByZeroException.
+    // ... a per-row comparison, ...
     [Fact]
-    public void EachDivideByZeroYieldsNullNeverGreaterThanZero()
+    public void EachDivideByZeroFailsFastEvenUnderComparison()
     {
         SampleDatabase db = new SampleDatabase();
 
@@ -286,20 +282,14 @@ public sealed class EachBroadcastAndLiteralTests
             pagination: null
         );
 
-        ProjectionResult result = new ProjectionResult(
+        _ = Assert.Throws<DivideByZeroException>(() => new ProjectionResult(
             new PureQLProjection(db.Datasets, query)
-        );
-
-        Assert.Equal(0, result.Count);
+        ));
     }
 
-    // eachDivide by zero, wrapped in eachNot(eachEquality(x, x)): null == null
-    // is true under lifted nullable equality (mirroring plain C# `(double?)
-    // null == (double?)null`), so negating it removes every row - the clearest
-    // possible signal that the division result is a deterministic null, not
-    // an exception and not some other sentinel value.
+    // ... or the divide-by-zero result compared against itself.
     [Fact]
-    public void EachDivideByZeroResultEqualsItselfUnderLiftedNullEquality()
+    public void EachDivideByZeroFailsFastEvenComparedAgainstItself()
     {
         SampleDatabase db = new SampleDatabase();
 
@@ -338,10 +328,8 @@ public sealed class EachBroadcastAndLiteralTests
             pagination: null
         );
 
-        ProjectionResult result = new ProjectionResult(
+        _ = Assert.Throws<DivideByZeroException>(() => new ProjectionResult(
             new PureQLProjection(db.Datasets, query)
-        );
-
-        Assert.Equal(0, result.Count);
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Part of the #72 roadmap: closes the 5 real KnownGap bugs surfaced by #104's negative-path tests, where the translator silently produced a wrong (empty) result instead of a defined failure.
- `CellValueExtractor`'s typed getters (`GetDoubleValue`, `GetBoolValue`, `GetDateOnlyValue`, `GetDateTimeValue`, `GetTimeOnlyValue`, `GetGuidValue`) now throw `FormatException` for non-empty, unparseable cell text (type mismatch or malformed stored data), instead of silently returning `null`.
- `GetTextValue` now requires the field to resolve to an existing column (`GetRequiredCell`), so a nonexistent column in WHERE/ORDER BY throws `KeyNotFoundException`, matching the SELECT path's existing behavior, instead of silently excluding rows / no-op ordering.
- `WhereExpressionBuilder.DivideDoubles` now throws `DivideByZeroException` for a zero divisor (when both operands are non-null), matching SQL division-by-zero semantics, instead of silently returning `null`.
- An empty cell text is unaffected and still represents SQL NULL, propagating as `null` through comparisons/aggregates as before - only genuinely unparseable non-empty text or unresolved fields now fail.

## What did NOT change
- The 4 remaining gaps from this round (NULL ordering on outer-join rows, ORDER BY on an aggregate/alias result, single-value `Arithmetic` in SELECT/WHERE, GROUP BY on a `NullField` key) are architecture/design-decision items, not bugs, and are left as documented `KnownGap` skips per the user's explicit scoping.

## Test changes
- Un-skips and renames the 5 `KnownGap` tests in `Errors/NegativePathTests.cs` (issue #104) that pinned this exact behavior - they now run as real assertions.
- Updates 3 pre-existing tests in `Where/Each/EachBroadcastAndLiteralTests.cs` that had pinned the old silent-null eachDivide-by-zero result; they now assert `DivideByZeroException` instead.

## Test plan
- [x] `dotnet build --no-restore -warnaserror` clean
- [x] `dotnet format --verify-no-changes` clean
- [x] `dotnet test --no-build --verbosity normal`: 378 total, 373 passed, 5 skipped (remaining documented design-decision gaps), 0 failed