### PR TITLE
Run ORDER BY after GROUP BY when aggregates/HAVING are present

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,12 @@ All translation work is done by internal classes:
 - **`SelectColumns`** — the single source of truth for output columns: one per `SelectExpression`, named by the alias (falling back to the field name) and typed by the value type; used by both the schema and the row projection
 - **`ValueText`** — formats computed (aggregate) values as canonical invariant cell text that `CellValueExtractor` round-trips
 
-The pipeline order in `RowsFromDatasets.Build` is: locate table → JOIN → WHERE → ORDER BY → (GROUP BY + HAVING + projection | per-row projection) → DISTINCT → pagination.
+The pipeline order in `RowsFromDatasets.Build` is: locate table → JOIN → WHERE →
+(GROUP BY + HAVING + projection → ORDER BY | ORDER BY → per-row projection) →
+DISTINCT → pagination. ORDER BY runs after GROUP BY/HAVING/projection when the
+query is in group mode (so it can order by an aggregate alias against the
+post-aggregation row), and before projection otherwise (so it can order by a
+column that isn't in the SELECT list, against the raw joined/filtered rows).
 
 The library is **not AOT-compatible** (`IsAotCompatible = false`) because the query translation relies on LINQ expression trees and reflection-based `IQueryable` composition.
 

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/RowsFromDatasets.cs
@@ -87,11 +87,6 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
             );
         }
 
-        if (query.OrderBy is not null)
-        {
-            queryable = OrderByApplicator.Apply(queryable, query.OrderBy);
-        }
-
         // HAVING with no groupBy still filters the implicit whole-set group,
         // so it engages group mode on its own.
         bool groupMode =
@@ -102,14 +97,35 @@ internal sealed record RowsFromDatasets : IQueryable<IRow>
                 && AggregateEvaluator.IsAggregate(singleValue)
             );
 
-        queryable = groupMode
-            ? GroupByApplicator.Apply(
+        if (groupMode)
+        {
+            queryable = GroupByApplicator.Apply(
                 queryable,
                 query.GroupBy,
                 query.Having,
                 query.SelectExpressions
-            )
-            : ApplyRowProjection(queryable, query.SelectExpressions);
+            );
+
+            // ORDER BY must see the post-aggregation, post-alias result when
+            // GROUP BY (or an implicit whole-set group) is present, so an
+            // aggregate alias like SUM(total) AS totalSum can be ordered by.
+            if (query.OrderBy is not null)
+            {
+                queryable = OrderByApplicator.Apply(queryable, query.OrderBy);
+            }
+        }
+        else
+        {
+            // Non-group queries may ORDER BY a column that isn't even in
+            // the SELECT list, so ORDER BY must run on the raw joined/
+            // filtered rows, before projection narrows the columns.
+            if (query.OrderBy is not null)
+            {
+                queryable = OrderByApplicator.Apply(queryable, query.OrderBy);
+            }
+
+            queryable = ApplyRowProjection(queryable, query.SelectExpressions);
+        }
 
         if (query.Distinct)
         {

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/OrderBy/OrderByExpansionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/OrderBy/OrderByExpansionTests.cs
@@ -426,22 +426,14 @@ public sealed class OrderByExpansionTests
         Assert.Equal(expected, actual);
     }
 
-    // KnownGap: the pipeline applies ORDER BY before GROUP BY (see
-    // RowsFromDatasets.Build), so an OrderByItem is evaluated against raw,
-    // pre-aggregation rows. An aggregate result (e.g. SUM(total) AS
-    // totalSum) only exists on the projected, post-group row - there is no
-    // raw column named "totalSum" for CellValueExtractor to resolve - so
-    // ordering by it is a silent no-op today instead of ordering the
-    // emitted groups by their aggregate value, as SQL's ORDER BY-after-
-    // GROUP BY semantics require.
-    [Fact(
-        Skip = "KnownGap: ORDER BY runs before GROUP BY in the pipeline, so "
-            + "an OrderByItem referencing an aggregate's alias resolves "
-            + "against pre-aggregation rows (no such column exists there) "
-            + "and silently no-ops instead of ordering the emitted groups "
-            + "by their aggregate result."
-    )]
-    [Trait("Status", "KnownGap")]
+    // In group mode, the pipeline applies ORDER BY after GROUP BY + HAVING +
+    // projection (see RowsFromDatasets.Build), so an OrderByItem is
+    // evaluated against the projected, post-group rows. An aggregate
+    // result (e.g. SUM(total) AS totalSum) exists as a column on that
+    // projected row, so ordering by its alias orders the emitted groups by
+    // their aggregate value, matching SQL's ORDER BY-after-GROUP BY
+    // semantics.
+    [Fact]
     public void OrderByAggregateResultOrdersEmittedGroupsByItsValue()
     {
         SampleDatabase db = new SampleDatabase();


### PR DESCRIPTION
Closes #126

## Summary

- `RowsFromDatasets.Build` restructured: in group mode (GROUP BY / HAVING / any aggregate select expression), ORDER BY now runs AFTER `GroupByApplicator.Apply` (GROUP BY + HAVING + projection), so ordering by an aggregate alias (e.g. `SUM(total) AS totalSum`) resolves against the post-aggregation projected row instead of silently no-oping.
- Non-group queries keep ORDER BY exactly where it was, before projection, since SQL allows ordering by a column outside the SELECT list against the raw joined/filtered rows.
- DISTINCT and pagination remain last, unchanged.
- Un-skipped `OrderByAggregateResultOrdersEmittedGroupsByItsValue` in `OrderBy/OrderByExpansionTests.cs` (previously `[Fact(Skip = "KnownGap: ...")]`) and updated its doc comment to describe the fix.
- Updated the pipeline-order description in CLAUDE.md.

## Regression checks

- `GroupBy/GroupByPipelineTests.GroupByAgeDescOrderThenPaginateReturnsExactOrderedWindow` — passes; now genuinely orders post-group but the plain key-field ordering produces the same visible result, so assertions were unchanged.
- Full `GroupBy/`, `Combined/`, and `OrderBy/` test folders explicitly re-run and pass, including `Combined/DeepNestingEndToEndTests.cs` (full pipeline: JOIN, WHERE, GROUP BY, HAVING, ORDER BY, DISTINCT, pagination together).
- Full suite: 378 total, 374 passed, 4 skipped, 0 failed.

## Test plan

- [x] `dotnet build --no-restore -warnaserror`
- [x] `dotnet format --verify-no-changes`
- [x] `dotnet test --no-build --verbosity normal` (full suite green)