### PR TITLE
OrderBy: NULL cells always sort last, regardless of direction

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/OrderByApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/OrderByApplicator.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Pure.RelationalSchema.Storage.Abstractions;
 using PureQL.CSharp.Model;
 
@@ -22,6 +23,76 @@ internal static class OrderByApplicator
         return ordered ?? source;
     }
 
+    private static IOrderedQueryable<IRow> OrderByNullsLast<TValue>(
+        IQueryable<IRow> source,
+        Expression<Func<IRow, TValue?>> selector,
+        bool descending
+    )
+        where TValue : struct
+    {
+        Func<IRow, TValue?> compiled = selector.Compile();
+
+        IOrderedQueryable<IRow> byNullRank = source.OrderBy(row =>
+            compiled(row).HasValue ? 0 : 1
+        );
+
+        return descending
+            ? byNullRank.ThenByDescending(selector)
+            : byNullRank.ThenBy(selector);
+    }
+
+    private static IOrderedQueryable<IRow> OrderByNullsLast(
+        IQueryable<IRow> source,
+        Expression<Func<IRow, string?>> selector,
+        bool descending
+    )
+    {
+        Func<IRow, string?> compiled = selector.Compile();
+
+        IOrderedQueryable<IRow> byNullRank = source.OrderBy(row =>
+            compiled(row) == null ? 1 : 0
+        );
+
+        return descending
+            ? byNullRank.ThenByDescending(selector)
+            : byNullRank.ThenBy(selector);
+    }
+
+    private static IOrderedQueryable<IRow> ThenByNullsLast<TValue>(
+        IOrderedQueryable<IRow> source,
+        Expression<Func<IRow, TValue?>> selector,
+        bool descending
+    )
+        where TValue : struct
+    {
+        Func<IRow, TValue?> compiled = selector.Compile();
+
+        IOrderedQueryable<IRow> byNullRank = source.ThenBy(row =>
+            compiled(row).HasValue ? 0 : 1
+        );
+
+        return descending
+            ? byNullRank.ThenByDescending(selector)
+            : byNullRank.ThenBy(selector);
+    }
+
+    private static IOrderedQueryable<IRow> ThenByNullsLast(
+        IOrderedQueryable<IRow> source,
+        Expression<Func<IRow, string?>> selector,
+        bool descending
+    )
+    {
+        Func<IRow, string?> compiled = selector.Compile();
+
+        IOrderedQueryable<IRow> byNullRank = source.ThenBy(row =>
+            compiled(row) == null ? 1 : 0
+        );
+
+        return descending
+            ? byNullRank.ThenByDescending(selector)
+            : byNullRank.ThenBy(selector);
+    }
+
     private static IOrderedQueryable<IRow> ApplyFirstOrderBy(
         IQueryable<IRow> source,
         OrderByItem item
@@ -31,65 +102,51 @@ internal static class OrderByApplicator
 
         return item.Field.Match(
             f =>
-                descending
-                    ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetBoolValue(row, f.Entity, f.Field)
-                    )
-                    : source.OrderBy(row =>
-                        CellValueExtractor.GetBoolValue(row, f.Entity, f.Field)
-                    ),
+                OrderByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetBoolValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field)
-                    )
-                    : source.OrderBy(row =>
-                        CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field)
-                    ),
+                OrderByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field)
-                    )
-                    : source.OrderBy(row =>
-                        CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field)
-                    ),
+                OrderByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field),
+                    descending
+                ),
             _ =>
                 descending
                     ? source.OrderByDescending(_ => (string?)null)
                     : source.OrderBy(_ => (string?)null),
             f =>
-                descending
-                    ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field)
-                    )
-                    : source.OrderBy(row =>
-                        CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field)
-                    ),
+                OrderByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field)
-                    )
-                    : source.OrderBy(row =>
-                        CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field)
-                    ),
+                OrderByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetGuidValue(row, f.Entity, f.Field)
-                    )
-                    : source.OrderBy(row =>
-                        CellValueExtractor.GetGuidValue(row, f.Entity, f.Field)
-                    ),
+                OrderByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetGuidValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.OrderByDescending(row =>
-                        CellValueExtractor.GetTextValue(row, f.Entity, f.Field)
-                    )
-                    : source.OrderBy(row =>
-                        CellValueExtractor.GetTextValue(row, f.Entity, f.Field)
-                    )
+                OrderByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetTextValue(row, f.Entity, f.Field),
+                    descending
+                )
         );
     }
 
@@ -102,65 +159,51 @@ internal static class OrderByApplicator
 
         return item.Field.Match(
             f =>
-                descending
-                    ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetBoolValue(row, f.Entity, f.Field)
-                    )
-                    : source.ThenBy(row =>
-                        CellValueExtractor.GetBoolValue(row, f.Entity, f.Field)
-                    ),
+                ThenByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetBoolValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field)
-                    )
-                    : source.ThenBy(row =>
-                        CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field)
-                    ),
+                ThenByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field)
-                    )
-                    : source.ThenBy(row =>
-                        CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field)
-                    ),
+                ThenByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field),
+                    descending
+                ),
             _ =>
                 descending
                     ? source.ThenByDescending(_ => (string?)null)
                     : source.ThenBy(_ => (string?)null),
             f =>
-                descending
-                    ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field)
-                    )
-                    : source.ThenBy(row =>
-                        CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field)
-                    ),
+                ThenByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field)
-                    )
-                    : source.ThenBy(row =>
-                        CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field)
-                    ),
+                ThenByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetGuidValue(row, f.Entity, f.Field)
-                    )
-                    : source.ThenBy(row =>
-                        CellValueExtractor.GetGuidValue(row, f.Entity, f.Field)
-                    ),
+                ThenByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetGuidValue(row, f.Entity, f.Field),
+                    descending
+                ),
             f =>
-                descending
-                    ? source.ThenByDescending(row =>
-                        CellValueExtractor.GetTextValue(row, f.Entity, f.Field)
-                    )
-                    : source.ThenBy(row =>
-                        CellValueExtractor.GetTextValue(row, f.Entity, f.Field)
-                    )
+                ThenByNullsLast(
+                    source,
+                    row => CellValueExtractor.GetTextValue(row, f.Entity, f.Field),
+                    descending
+                )
         );
     }
 }

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/OrderBy/OrderByExpansionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/OrderBy/OrderByExpansionTests.cs
@@ -318,21 +318,15 @@ public sealed class OrderByExpansionTests
         Assert.Equal(expected, actual);
     }
 
-    // KnownGap: rows produced by an unmatched LEFT JOIN side carry an empty
-    // (NULL-equivalent) cell for the joined column. SQL engines commonly
-    // default ascending ORDER BY to NULLS LAST (e.g. PostgreSQL), but
-    // OrderByApplicator sorts via C#'s Nullable<T> comparison, where null
-    // compares less than every value, so unmatched rows land first instead.
-    // The query language has no NULLS FIRST/LAST clause to override this, so
-    // NULL placement is undefined/unspecified by the library today.
-    [Fact(
-        Skip = "KnownGap: ascending ORDER BY over a nullable (unmatched "
-            + "LEFT JOIN) column places NULLs first, following C#'s "
-            + "Nullable<T> comparer, instead of NULLS LAST as many SQL "
-            + "engines default; the query model has no NULLS FIRST/LAST "
-            + "control to pin the intended behavior either way."
-    )]
-    [Trait("Status", "KnownGap")]
+    // Rows produced by an unmatched LEFT JOIN side carry an empty
+    // (NULL-equivalent) cell for the joined column. OrderByApplicator now
+    // implements an intentional NULLS LAST contract regardless of sort
+    // direction (matching PostgreSQL/Oracle/SQL Server's default): every
+    // order-by item keys first by "is this cell NULL" (always ascending),
+    // then by the real value in the requested direction. This test pins
+    // ascending; see OrderByDescendingWithUnmatchedLeftJoinRowsPlacesNullsLast
+    // below for the descending companion.
+    [Fact]
     public void OrderByAscendingWithUnmatchedLeftJoinRowsPlacesNullsLast()
     {
         SampleDatabase db = new SampleDatabase();
@@ -417,6 +411,107 @@ public sealed class OrderByExpansionTests
             "Dan",
             "Bob",
             "Cara",
+            "Eve",
+            "Fay",
+        ];
+
+        string?[] actual = [.. result.Column(SampleDatabase.Users.Name)];
+
+        Assert.Equal(expected, actual);
+    }
+
+    // Companion to the ascending test above: pins that NULLS LAST also
+    // holds under a descending sort (previously the only direction where
+    // the old default Nullable<T> comparer already happened to place
+    // NULLs last), proving the "regardless of direction" half of the
+    // contract, not just the ascending half.
+    [Fact]
+    public void OrderByDescendingWithUnmatchedLeftJoinRowsPlacesNullsLast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Join usersToOrders = new Join(
+            JoinType.Left,
+            SampleDatabase.Orders.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Name
+                            )
+                        )
+                    )
+                ),
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [usersToOrders],
+            groupBy: null,
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    SortDirection.Desc
+                ),
+            ],
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        // Eve and Fay place no orders, so their joined Total is NULL.
+        // NULLS LAST holds here too: matched rows sorted descending first,
+        // then the unmatched users trailing in their original relative
+        // order (Ann/Dan tie at 100.50; a stable sort keeps Ann, whose
+        // order row precedes Dan's, ahead of Dan for that tie).
+        string[] expected =
+        [
+            "Cara",
+            "Bob",
+            "Ann",
+            "Dan",
+            "Cara",
+            "Ann",
             "Eve",
             "Fay",
         ];

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Types/NullSemanticsTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Types/NullSemanticsTests.cs
@@ -365,17 +365,18 @@ public sealed class NullSemanticsTests
         );
     }
 
-    // ORDER BY user_score ASC/DESC: pins today's actual behavior rather than
-    // asserting a SQL-standard NULLS FIRST/LAST rule (the spec leaves the
-    // ordering of NULLs relative to values engine-defined, and this library
-    // simply delegates to .NET's default nullable comparer via
-    // IQueryable.OrderBy/OrderByDescending on double?, where null sorts as
-    // the smallest possible value). The expected sequence below is produced
-    // by the identical LINQ ordering over the ground-truth records, so a
-    // change to this behavior will show up here rather than only in
-    // production.
+    // ORDER BY user_score ASC/DESC: OrderByApplicator implements an
+    // intentional NULLS LAST contract, regardless of sort direction
+    // (matching PostgreSQL/Oracle/SQL Server's default) - see issue #125.
+    // Bob and Dan's NULL Score cells must always sort after every non-NULL
+    // Score, whether ascending or descending. The expected sequence below
+    // is built explicitly as non-NULL rows (sorted by score in the
+    // requested direction) followed by NULL rows in their original
+    // relative order, mirroring that contract rather than relying on
+    // .NET's default Nullable<T> comparer (which would place NULLs first
+    // for ascending).
     [Fact]
-    public void OrderByAscendingPlacesNullScoreCellsFirst()
+    public void OrderByAscendingPlacesNullScoreCellsLast()
     {
         SampleDatabase db = new SampleDatabase();
 
@@ -417,13 +418,24 @@ public sealed class NullSemanticsTests
 
         string[] expected =
         [
-            .. db.UserRows.OrderBy(user => user.Score).Select(user => user.UserName),
+            .. db.UserRows
+                .Where(user => user.Score.HasValue)
+                .OrderBy(user => user.Score)
+                .Select(user => user.UserName),
+            .. db.UserRows
+                .Where(user => !user.Score.HasValue)
+                .Select(user => user.UserName),
         ];
 
-        Assert.Equal(["Bob", "Dan"], expected[..2]);
+        Assert.Equal(["Bob", "Dan"], expected[^2..]);
         Assert.Equal(expected, result.Column(SampleDatabase.Users.Name).ToArray());
     }
 
+    // Descending companion: proves NULLS LAST holds in the direction where
+    // the old default Nullable<T> comparer already happened to agree, so
+    // this test alone cannot distinguish the old and new behavior - it is
+    // the ascending test above (now renamed to ...PlacesNullsLast) that
+    // pins the actual behavior change.
     [Fact]
     public void OrderByDescendingPlacesNullScoreCellsLast()
     {
@@ -465,6 +477,11 @@ public sealed class NullSemanticsTests
             new PureQLProjection(db.Datasets, query)
         );
 
+        // For a descending sort, NULLS LAST happens to coincide with what
+        // .NET's default Nullable<T> comparer already produces (null
+        // compares as the smallest value, so it sorts last when
+        // descending), so a plain OrderByDescending over the ground-truth
+        // records still reflects the intentional contract here.
         string[] expected =
         [
             .. db.UserRows


### PR DESCRIPTION
## Summary

- Adopts an intentional NULLS LAST ordering contract for `OrderByApplicator`: regardless of ascending/descending direction, rows with a NULL cell for the sort key now always sort after every row with a non-NULL value (matching PostgreSQL/Oracle/SQL Server's default convention).
- Previously the applicator delegated straight to C#'s default `Nullable<T>` comparer, which places NULLs first ascending and last descending - undefined/inconsistent from a SQL-semantics point of view.
- Each order-by key (first-level `OrderBy`/`OrderByDescending` and chained `ThenBy`/`ThenByDescending`, across all seven field types) is now built from a two-part key: an always-ascending "is this value null" rank, followed by the real value sorted in the requested direction.
- Un-skips `OrderByAscendingWithUnmatchedLeftJoinRowsPlacesNullsLast` (previously pinned as a `KnownGap`) now that the behavior is defined, and adds a descending companion test (`OrderByDescendingWithUnmatchedLeftJoinRowsPlacesNullsLast`) proving nulls-last holds in both directions.
- Fixes the two now-conflicting tests in `NullSemanticsTests.cs`: renames/rewrites `OrderByAscendingPlacesNullScoreCellsFirst` to `OrderByAscendingPlacesNullScoreCellsLast` (with an expected sequence computed as non-null-sorted-by-score followed by null rows in original relative order), and updates the comment on `OrderByDescendingPlacesNullScoreCellsLast` to reflect the new intentional reasoning instead of the old "delegates to .NET's default nullable comparer" framing.

Closes #125
Part of the #72 roadmap.

## Test plan
- [x] `dotnet restore`
- [x] `dotnet build --no-restore -warnaserror`
- [x] `dotnet format --verify-no-changes`
- [x] `dotnet test --no-build --verbosity normal` - 379 total, 375 passed, 4 skipped (KnownGap), 0 failed