### PR TITLE
Evaluate single-value Arithmetic with literal-constant operands

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/LiteralArithmeticEvaluator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/LiteralArithmeticEvaluator.cs
@@ -1,0 +1,97 @@
+using PureQL.CSharp.Model.Arithmetics;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection;
+
+// Evaluates a single-value NumberReturning to a constant double, but only
+// when every operand, recursively, is a pure literal (NumberScalar, or
+// Arithmetic composed entirely of such). Parameters, aggregates, and Count
+// have no meaning outside a row/group context, so any of those appearing
+// anywhere in the tree makes the whole expression non-literal. Shared by
+// ScalarCell (SELECT) and WhereExpressionBuilder (WHERE) so both scalar,
+// no-row-data paths fold Add/Subtract/Multiply/Divide the same way as the
+// per-row EachArithmetic family, left-to-right over the Arguments list.
+internal static class LiteralArithmeticEvaluator
+{
+    internal static bool TryEvaluate(NumberReturning returning, out double value)
+    {
+        double? evaluated = returning.Match(
+            _ => null,
+            scalar => scalar.Value,
+            EvaluateArithmetic,
+            _ => null,
+            _ => null
+        );
+
+        value = evaluated ?? default;
+        return evaluated.HasValue;
+    }
+
+    private static double? EvaluateArithmetic(Arithmetic arithmetic)
+    {
+        IEnumerable<NumberReturning> arguments = arithmetic.Match(
+            add => add.Arguments,
+            divide => divide.Arguments,
+            multiply => multiply.Arguments,
+            subtract => subtract.Arguments
+        );
+
+        Func<double, double, double> reduce = arithmetic.Match<
+            Func<double, double, double>
+        >(
+            add => Add,
+            divide => Divide,
+            multiply => Multiply,
+            subtract => Subtract
+        );
+
+        return Fold(arguments, reduce);
+    }
+
+    private static double? Fold(
+        IEnumerable<NumberReturning> arguments,
+        Func<double, double, double> reduce
+    )
+    {
+        double? accumulator = null;
+
+        foreach (NumberReturning argument in arguments)
+        {
+            if (!TryEvaluate(argument, out double operand))
+            {
+                return null;
+            }
+
+            accumulator = accumulator.HasValue
+                ? reduce(accumulator.Value, operand)
+                : operand;
+        }
+
+        return accumulator;
+    }
+
+    private static double Add(double a, double b)
+    {
+        return a + b;
+    }
+
+    private static double Multiply(double a, double b)
+    {
+        return a * b;
+    }
+
+    private static double Subtract(double a, double b)
+    {
+        return a - b;
+    }
+
+    private static double Divide(double a, double b)
+    {
+        return b == 0
+            ? throw new DivideByZeroException(
+                "Literal arithmetic division by zero: division by zero is a "
+                    + "defined failure, matching SQL division-by-zero semantics."
+            )
+            : a / b;
+    }
+}

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/ScalarCell.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/ScalarCell.cs
@@ -16,7 +16,8 @@ internal static class ScalarCell
             boolean => boolean.IsT1,
             date => date.IsT1,
             dateTime => dateTime.IsT1,
-            number => number.IsT1,
+            number => number.IsT1
+                || LiteralArithmeticEvaluator.TryEvaluate(number, out double _),
             text => text.IsT1,
             time => time.IsT1,
             uuid => uuid.IsT1
@@ -34,10 +35,17 @@ internal static class ScalarCell
             boolean => ValueText.From(boolean.AsT1.Value),
             date => ValueText.From(date.AsT1.Value),
             dateTime => ValueText.From(dateTime.AsT1.Value),
-            number => ValueText.From(number.AsT1.Value),
+            number => ValueText.From(NumberValue(number)),
             text => text.AsT1.Value,
             time => ValueText.From(time.AsT1.Value),
             uuid => ValueText.From(uuid.AsT1.Value)
         );
+    }
+
+    private static double NumberValue(NumberReturning number)
+    {
+        return LiteralArithmeticEvaluator.TryEvaluate(number, out double value)
+            ? value
+            : number.AsT1.Value;
     }
 }

--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/WhereExpressionBuilder.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/WhereExpressionBuilder.cs
@@ -1180,9 +1180,12 @@ internal static class WhereExpressionBuilder
         return returning.Match(
             _ => throw new NotSupportedException(ParameterNotSupported),
             scalar => Expression.Constant((double?)scalar.Value, typeof(double?)),
-            _ => throw new NotSupportedException(
-                "Single-value Arithmetic outside per-row context is not supported."
-            ),
+            _ => LiteralArithmeticEvaluator.TryEvaluate(returning, out double literal)
+                ? Expression.Constant((double?)literal, typeof(double?))
+                : throw new NotSupportedException(
+                    "Single-value Arithmetic outside per-row context is not "
+                        + "supported unless every operand is a literal constant."
+                ),
             _ => throw new NotSupportedException(AggregateNotSupported),
             _ => throw new NotSupportedException(AggregateNotSupported)
         );

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/LiteralArithmeticProjectionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/LiteralArithmeticProjectionTests.cs
@@ -1,0 +1,143 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Arithmetics;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Select;
+
+// A single-value Arithmetic whose operands are all literal constants
+// (NumberScalar, or nested Arithmetic composed entirely of such) evaluates
+// once, exactly like a plain scalar constant (ScalarCell), and repeats on
+// every output row. Parameters, aggregates, and Count remain unsupported
+// operands (ScalarUnsupportedTests) - this is strictly the literal-only
+// case.
+[Trait("Clause", "Select")]
+[Trait("Feature", "LiteralArithmeticProjection")]
+public sealed class LiteralArithmeticProjectionTests
+{
+    [Fact]
+    public void NestedArithmeticOfLiteralsProjectsFoldedConstant()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Arithmetic(
+                                new Multiply(
+                                    [
+                                        new NumberReturning(
+                                            new Arithmetic(
+                                                new Add(
+                                                    [
+                                                        new NumberReturning(
+                                                            new NumberScalar(1)
+                                                        ),
+                                                        new NumberReturning(
+                                                            new NumberScalar(2)
+                                                        ),
+                                                    ]
+                                                )
+                                            )
+                                        ),
+                                        new NumberReturning(new NumberScalar(3)),
+                                    ]
+                                )
+                            )
+                        )
+                    ),
+                    "result"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(["result"], result.ColumnNames);
+        Assert.NotEmpty(result.Rows);
+        Assert.All(result.Rows, row => Assert.Equal(9, row.Double("result")));
+    }
+
+    [Fact]
+    public void LiteralArithmeticSubtractAndDivideFoldLeftToRight()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Arithmetic(
+                                new Divide(
+                                    [
+                                        new NumberReturning(
+                                            new Arithmetic(
+                                                new Subtract(
+                                                    [
+                                                        new NumberReturning(
+                                                            new NumberScalar(10)
+                                                        ),
+                                                        new NumberReturning(
+                                                            new NumberScalar(4)
+                                                        ),
+                                                    ]
+                                                )
+                                            )
+                                        ),
+                                        new NumberReturning(new NumberScalar(2)),
+                                    ]
+                                )
+                            )
+                        )
+                    ),
+                    "result"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.All(result.Rows, row => Assert.Equal(3, row.Double("result")));
+    }
+
+    [Fact]
+    public void LiteralArithmeticDivideByZeroFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Arithmetic(
+                                new Divide(
+                                    [
+                                        new NumberReturning(new NumberScalar(1)),
+                                        new NumberReturning(new NumberScalar(0)),
+                                    ]
+                                )
+                            )
+                        )
+                    ),
+                    "result"
+                ),
+            ]
+        );
+
+        _ = Assert.Throws<DivideByZeroException>(() =>
+            new PureQLProjection(db.Datasets, query)
+        );
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/ScalarUnsupportedTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/ScalarUnsupportedTests.cs
@@ -11,12 +11,13 @@ using PureQL.CSharp.Model.Scalars;
 
 namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Select;
 
-// Scalar constants are the only supported non-aggregate SingleValueReturning
-// select projections. Parameters (no binding API), single-value arithmetic
-// and boolean composites still have no defined result through this entry
-// point, so the translator fails fast with NotSupportedException instead of
-// silently producing wrong cells. These tests pin that explicit-failure
-// contract.
+// Scalar constants, and single-value Arithmetic whose operands are all
+// literal constants, are the only supported non-aggregate
+// SingleValueReturning select projections. Parameters (no binding API),
+// Arithmetic containing a parameter or aggregate operand, and boolean
+// composites still have no defined result through this entry point, so the
+// translator fails fast with NotSupportedException instead of silently
+// producing wrong cells. These tests pin that explicit-failure contract.
 [Trait("Clause", "Select")]
 [Trait("Feature", "ScalarProjection")]
 public sealed class ScalarUnsupportedTests
@@ -44,7 +45,7 @@ public sealed class ScalarUnsupportedTests
     }
 
     [Fact]
-    public void SingleValueArithmeticInSelectFailsFast()
+    public void SingleValueArithmeticWithParameterOperandInSelectFailsFast()
     {
         SampleDatabase db = new SampleDatabase();
 
@@ -58,7 +59,9 @@ public sealed class ScalarUnsupportedTests
                                 new Add(
                                     [
                                         new NumberReturning(new NumberScalar(1)),
-                                        new NumberReturning(new NumberScalar(2)),
+                                        new NumberReturning(
+                                            new NumberParameter("bonus")
+                                        ),
                                     ]
                                 )
                             )

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/SelectExpansionTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Select/SelectExpansionTests.cs
@@ -742,18 +742,12 @@ public sealed class SelectExpansionTests
         }
     }
 
-    // KnownGap: alias renames output column for a computed/expression column.
-    // Computed select columns (single-value Arithmetic) currently fail fast
-    // with NotSupportedException (see ScalarUnsupportedTests); once
-    // implemented, per SQL result-set semantics the alias should rename the
-    // computed column exactly as it does for a plain field (SelectAliasTests,
-    // AliasCoverageTests). This pins the spec-correct expectation.
-    [Fact(
-        Skip = "KnownGap: single-value Arithmetic select expressions fail fast "
-            + "with NotSupportedException; alias renaming for computed columns "
-            + "is unimplemented (see Semantics/README.md)."
-    )]
-    [Trait("Status", "KnownGap")]
+    // Alias renames output column for a computed/expression column. A
+    // single-value Arithmetic whose operands are all literal constants now
+    // evaluates once (see ScalarCell/LiteralArithmeticEvaluator), and per SQL
+    // result-set semantics the alias renames the computed column exactly as
+    // it does for a plain field (SelectAliasTests, AliasCoverageTests).
+    [Fact]
     public void AliasRenamesComputedArithmeticColumn()
     {
         SampleDatabase db = new SampleDatabase();

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Scalar/NestedBooleanTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Scalar/NestedBooleanTests.cs
@@ -1161,20 +1161,13 @@ public sealed class NestedBooleanTests
         Assert.Equal(0, result.Count);
     }
 
-    // KnownGap: single-value Arithmetic outside a per-row (each*) context has
-    // no defined result through the scalar WHERE-predicate entry point either
-    // - distinct from the Select-path gap pinned in
-    // Select/ScalarUnsupportedTests.SingleValueArithmeticInSelectFailsFast.
-    // WhereExpressionBuilder.BuildNumberReturningAsExpr throws
-    // NotSupportedException for the Arithmetic arm, so a predicate like
-    // `where (1 + 2) > total` fails fast rather than silently comparing
-    // against the wrong value.
-    [Fact(
-        Skip = "KnownGap: single-value Arithmetic in a scalar WHERE predicate "
-            + "fails fast (NotSupportedException), see #97"
-    )]
-    [Trait("Status", "KnownGap")]
-    public void ScalarArithmeticInComparisonPredicateFailsFast()
+    // A single-value Arithmetic whose operands are all literal constants now
+    // evaluates once, outside a per-row (each*) context, through the scalar
+    // WHERE-predicate entry point - distinct from the per-row EachArithmetic
+    // path exercised elsewhere in this suite. `where (1 + 2) > 0` folds to
+    // `3 > 0`, a constant-true predicate matching every row.
+    [Fact]
+    public void ScalarArithmeticInComparisonPredicateMatchesEveryRow()
     {
         SampleDatabase db = new SampleDatabase();
 
@@ -1217,10 +1210,10 @@ public sealed class NestedBooleanTests
             pagination: null
         );
 
-        NotSupportedException exception = Assert.Throws<NotSupportedException>(
-            () => new PureQLProjection(db.Datasets, query)
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
         );
 
-        Assert.NotNull(exception);
+        Assert.Equal(db.OrderRows.Count, result.Count);
     }
 }


### PR DESCRIPTION
## Summary

- Implements the "single-value Arithmetic" known gap for the literal-only case: SELECT and scalar WHERE expressions with an `Add`/`Subtract`/`Multiply`/`Divide` whose operands are all `NumberScalar` (recursively, including nested `Arithmetic`) now evaluate once to a constant `double` instead of throwing.
- New internal `LiteralArithmeticEvaluator`, shared by `ScalarCell` (SELECT) and `WhereExpressionBuilder.BuildNumberReturningAsExpr` (WHERE), recursively resolves a `NumberReturning` to a literal `double` when possible, folding `Arguments` left-to-right the same way the existing per-row `EachArithmetic` folds its `Values` (`Add`/`Subtract`/`Multiply` via straightforward reduction; `Divide` throws `DivideByZeroException` on a zero divisor, matching the `EachDivide` convention).
- `Arithmetic` containing a `NumberParameter`, `NumberAggregate`, or `Count` operand anywhere in the tree is still genuinely unsupported and continues to throw `NotSupportedException`.
- Updated `ScalarUnsupportedTests.SingleValueArithmeticInSelectFailsFast` (renamed `...WithParameterOperandInSelectFailsFast`) to use a non-literal operand, since the old all-literal case is now supported.
- Un-skipped `SelectExpansionTests.AliasRenamesComputedArithmeticColumn` (alias renames a computed literal column, same as a plain field) and `NestedBooleanTests.ScalarArithmeticInComparisonPredicateFailsFast` (renamed `...MatchesEveryRow`, since `(1 + 2) > 0` now folds to a true predicate matching every row).
- Added `Select/LiteralArithmeticProjectionTests.cs`: nested `Arithmetic` folding (`(1+2)*3` -> 9), left-to-right subtract/divide fold, and a literal divide-by-zero fail-fast case.

Closes #129

## Test plan

- [x] `dotnet build --no-restore -warnaserror`
- [x] `dotnet format --verify-no-changes`
- [x] `dotnet test --no-build --verbosity normal` - 378 passed, 3 skipped (unrelated known gaps: NULL ordering direction, ORDER BY-after-GROUP BY reordering, GROUP BY NullField key), 0 failed