### PR TITLE
Update package validation baseline to 0.1.0-preview.2.2.0

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/Pure.RelationalSchema.Storage.PureQL.Projection.csproj
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/Pure.RelationalSchema.Storage.PureQL.Projection.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>false</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.2.1.3</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.2.2.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Storage.PureQL.Projection</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.2.1.3` to `0.1.0-preview.2.2.0` following the successful publish.