### PR TITLE
Explain the applicable naming rule when an orderBy field can't be resolved

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/OrderByApplicator.cs
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/OrderByApplicator.cs
@@ -23,6 +23,65 @@ internal static class OrderByApplicator
         return ordered ?? source;
     }
 
+    // CellValueExtractor.GetRequiredCell throws a bare KeyNotFoundException
+    // naming only the field when no column matches. For orderBy specifically
+    // that's a frequent trial-and-error trap, because which name is expected
+    // depends on query mode (RowsFromDatasets.Build): without groupBy, the
+    // sort runs on raw pre-projection rows and needs the source column name;
+    // with groupBy/aggregates, it runs on the projected, post-alias rows and
+    // needs the select alias instead. Re-throwing with that rule spelled out
+    // turns a silent trap into an actionable message, without changing which
+    // name resolves in which mode.
+    private static TValue? ResolveOrThrow<TValue>(
+        Func<TValue?> resolve,
+        string entity,
+        string fieldName
+    )
+        where TValue : struct
+    {
+        try
+        {
+            return resolve();
+        }
+        catch (KeyNotFoundException ex)
+        {
+            throw OrderByFieldNotFound(entity, fieldName, ex);
+        }
+    }
+
+    private static string? ResolveOrThrow(
+        Func<string?> resolve,
+        string entity,
+        string fieldName
+    )
+    {
+        try
+        {
+            return resolve();
+        }
+        catch (KeyNotFoundException ex)
+        {
+            throw OrderByFieldNotFound(entity, fieldName, ex);
+        }
+    }
+
+    private static KeyNotFoundException OrderByFieldNotFound(
+        string entity,
+        string fieldName,
+        Exception inner
+    )
+    {
+        return new KeyNotFoundException(
+            $"orderBy field '{fieldName}' on entity '{entity}' has no "
+                + "matching column in the rows being sorted. Without "
+                + "groupBy, orderBy fields must name the original source "
+                + "column (as it appears before projection); with groupBy "
+                + "or aggregates, they must name the select alias of the "
+                + "projected column instead.",
+            inner
+        );
+    }
+
     private static IOrderedQueryable<IRow> OrderByNullsLast<TValue>(
         IQueryable<IRow> source,
         Expression<Func<IRow, TValue?>> selector,
@@ -104,19 +163,34 @@ internal static class OrderByApplicator
             f =>
                 OrderByNullsLast(
                     source,
-                    row => CellValueExtractor.GetBoolValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetBoolValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 OrderByNullsLast(
                     source,
-                    row => CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 OrderByNullsLast(
                     source,
-                    row => CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             _ =>
@@ -126,25 +200,45 @@ internal static class OrderByApplicator
             f =>
                 OrderByNullsLast(
                     source,
-                    row => CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 OrderByNullsLast(
                     source,
-                    row => CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 OrderByNullsLast(
                     source,
-                    row => CellValueExtractor.GetGuidValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetGuidValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 OrderByNullsLast(
                     source,
-                    row => CellValueExtractor.GetTextValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetTextValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 )
         );
@@ -161,19 +255,34 @@ internal static class OrderByApplicator
             f =>
                 ThenByNullsLast(
                     source,
-                    row => CellValueExtractor.GetBoolValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetBoolValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 ThenByNullsLast(
                     source,
-                    row => CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetDateOnlyValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 ThenByNullsLast(
                     source,
-                    row => CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetDateTimeValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             _ =>
@@ -183,25 +292,45 @@ internal static class OrderByApplicator
             f =>
                 ThenByNullsLast(
                     source,
-                    row => CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetDoubleValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 ThenByNullsLast(
                     source,
-                    row => CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetTimeOnlyValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 ThenByNullsLast(
                     source,
-                    row => CellValueExtractor.GetGuidValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetGuidValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 ),
             f =>
                 ThenByNullsLast(
                     source,
-                    row => CellValueExtractor.GetTextValue(row, f.Entity, f.Field),
+                    row =>
+                        ResolveOrThrow(
+                            () => CellValueExtractor.GetTextValue(row, f.Entity, f.Field),
+                            f.Entity,
+                            f.Field
+                        ),
                     descending
                 )
         );

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/OrderBy/OrderByFieldResolutionErrorTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/OrderBy/OrderByFieldResolutionErrorTests.cs
@@ -1,0 +1,159 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.OrderBy;
+
+// orderBy field resolution intentionally differs by query mode
+// (RowsFromDatasets.Build): without groupBy it runs pre-projection and
+// needs the source column name (OrderByExpansionTests.
+// OrderByAliasedSelectColumnStillOrdersByUnderlyingField pins this); with
+// groupBy/aggregates it runs post-projection and needs the select alias
+// (OrderByExpansionTests.OrderByAggregateResultOrdersEmittedGroupsByItsValue
+// pins that). Both rules stay unchanged here (issue #135) - only the
+// failure a caller hits by using the wrong name for the current mode is
+// pinned as a KeyNotFoundException whose message names the field/entity and
+// spells out which name is expected in which mode, instead of the bare
+// "Row has no column named 'x'." message that gives no hint why.
+[Trait("Clause", "OrderBy")]
+[Trait("Feature", "OrderByFieldResolutionError")]
+public sealed class OrderByFieldResolutionErrorTests
+{
+    [Fact]
+    public void OrderingByAliasWithoutGroupByThrowsWithRuleInMessage()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Age
+                            )
+                        )
+                    ),
+                    "years"
+                ),
+            ],
+            where: null,
+            join: null,
+            groupBy: null,
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new NumberField(SampleDatabase.Users.Entity, "years")
+                    ),
+                    SortDirection.Desc
+                ),
+            ],
+            pagination: null
+        );
+
+        KeyNotFoundException exception = Assert.Throws<KeyNotFoundException>(
+            () => new ProjectionResult(new PureQLProjection(db.Datasets, query))
+        );
+
+        Assert.Contains("years", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(
+            "source column",
+            exception.Message,
+            StringComparison.Ordinal
+        );
+        Assert.Contains(
+            "select alias",
+            exception.Message,
+            StringComparison.Ordinal
+        );
+    }
+
+    [Fact]
+    public void OrderingByOriginalFieldNameInGroupByThrowsWithRuleInMessage()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    ),
+                    "status"
+                ),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new NumberAggregate(
+                                new SumNumber(
+                                    new NumberArrayReturning(
+                                        new NumberField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Total
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "totalSum"
+                ),
+            ],
+            where: null,
+            join: null,
+            [
+                new Field(
+                    new StringField(
+                        SampleDatabase.Orders.Entity,
+                        SampleDatabase.Orders.Status
+                    )
+                ),
+            ],
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    SortDirection.Asc
+                ),
+            ],
+            pagination: null
+        );
+
+        KeyNotFoundException exception = Assert.Throws<KeyNotFoundException>(
+            () => new ProjectionResult(new PureQLProjection(db.Datasets, query))
+        );
+
+        Assert.Contains(
+            SampleDatabase.Orders.Total,
+            exception.Message,
+            StringComparison.Ordinal
+        );
+        Assert.Contains(
+            "source column",
+            exception.Message,
+            StringComparison.Ordinal
+        );
+        Assert.Contains(
+            "select alias",
+            exception.Message,
+            StringComparison.Ordinal
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `orderBy` field resolution intentionally differs by query mode (`RowsFromDatasets.Build`): without `groupBy` it runs on raw pre-projection rows and needs the original source column name (pinned by `OrderByExpansionTests.OrderByAliasedSelectColumnStillOrdersByUnderlyingField`); with `groupBy`/aggregates it runs on the projected rows and needs the select alias (pinned by `OrderByExpansionTests.OrderByAggregateResultOrdersEmittedGroupsByItsValue`). **Both rules are unchanged by this PR.**
- Picking the wrong name for the current mode previously surfaced as a bare `KeyNotFoundException: Row has no column named 'x'.`, with no hint about the two-rule contract, deep inside `Enumerable.EnumerableSorter.ComputeKeys`.
- `OrderByApplicator` now wraps field resolution and rethrows the **same exception type** (preserving the existing `KeyNotFoundException` contract pinned elsewhere, e.g. `NegativePathTests`) with a message that names the field/entity and explains which name is expected in which mode.

Closes #135

## Test plan
- [x] Added `OrderBy/OrderByFieldResolutionErrorTests.cs` covering both directions (ordering by alias without `groupBy`, ordering by source column with `groupBy`); confirmed both fail against the pre-fix message (missing "source column"/"select alias" hints) before the change.
- [x] `dotnet build --no-restore -warnaserror`
- [x] `dotnet format --verify-no-changes`
- [x] `dotnet test --no-build` — 384 tests, 383 passed, 1 skipped (pre-existing), 0 failed — including existing `KeyNotFoundException`-type-pinning tests in `NegativePathTests` and the aliased/aggregate `OrderByExpansionTests` behavioral pins, all unaffected.