### PR TITLE
Test expansion: whole-array equal sequence tests across all 7 element types

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/BooleanArrayEqualitySequenceTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/BooleanArrayEqualitySequenceTests.cs
@@ -1,0 +1,202 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayEqualities;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// Boolean arm of the whole-array `equal` (`Equality` -> `ArrayEquality`)
+// sequence-equality predicate. See ArrayEqualitySequenceTests.cs (the Number
+// arm) for the full rationale: this is a single-value predicate evaluated
+// once for the whole query, distinct from the per-row `eachEqual` family, and
+// field-vs-literal operand shapes fail fast with NotSupportedException per
+// the ratified issue #114 contract rather than silently degrading to per-row
+// Enumerable.Contains ("IN") membership.
+[Trait("Clause", "Where")]
+[Trait("Feature", "ArrayEqualitySequence")]
+public sealed class BooleanArrayEqualitySequenceTests
+{
+    private static SelectExpression OrderIdSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new UuidArrayReturning(
+                    new UuidField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Id)
+                )
+            )
+        );
+    }
+
+    // Two identical literal arrays: SequenceEqual is true, so the predicate
+    // (evaluated once, applied to the whole result) keeps every row.
+    [Fact]
+    public void WholeBooleanArrayEqualityOfTwoEqualLiteralArraysKeepsEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new BooleanArrayEquality(
+                            new BooleanArrayReturning(
+                                new BooleanArrayScalar([true, false, true])
+                            ),
+                            new BooleanArrayReturning(
+                                new BooleanArrayScalar([true, false, true])
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count, result.Count);
+    }
+
+    // Two literal arrays with the same length but a different order:
+    // SequenceEqual is false (order-sensitive), so every row is removed.
+    [Fact]
+    public void WholeBooleanArrayEqualityOfTwoReorderedLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new BooleanArrayEquality(
+                            new BooleanArrayReturning(
+                                new BooleanArrayScalar([true, false, true])
+                            ),
+                            new BooleanArrayReturning(
+                                new BooleanArrayScalar([true, true, false])
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Field vs. literal-array whole-array `equal` (either operand order) is
+    // not implemented as true sequence equality (see issue #114) - the
+    // translator fails fast with NotSupportedException instead of silently
+    // falling back to per-row Enumerable.Contains ("IN") membership, which
+    // would give a wrong answer here: reversing the literal doesn't change
+    // set membership, so a membership-based implementation would wrongly
+    // keep every row.
+    [Fact]
+    public void WholeBooleanArrayEqualityOfFieldAgainstLiteralFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        bool[] reversedInStock =
+        [
+            .. db.ProductRows.Select(product => product.ProductInStock).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new BooleanArrayEquality(
+                            new BooleanArrayReturning(
+                                new BooleanField(
+                                    SampleDatabase.Products.Entity,
+                                    SampleDatabase.Products.InStock
+                                )
+                            ),
+                            new BooleanArrayReturning(
+                                new BooleanArrayScalar(reversedInStock)
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+
+    // Mirrors the test above with the operand order swapped (literal array
+    // on the left, field on the right) to cover the other arm of
+    // BuildContainmentEquality's field-vs-literal handling.
+    [Fact]
+    public void WholeBooleanArrayEqualityOfLiteralAgainstFieldFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        bool[] reversedInStock =
+        [
+            .. db.ProductRows.Select(product => product.ProductInStock).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new BooleanArrayEquality(
+                            new BooleanArrayReturning(
+                                new BooleanArrayScalar(reversedInStock)
+                            ),
+                            new BooleanArrayReturning(
+                                new BooleanField(
+                                    SampleDatabase.Products.Entity,
+                                    SampleDatabase.Products.InStock
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/DateArrayEqualitySequenceTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/DateArrayEqualitySequenceTests.cs
@@ -1,0 +1,275 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayEqualities;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// Date arm of the whole-array `equal` (`Equality` -> `ArrayEquality`)
+// sequence-equality predicate. See ArrayEqualitySequenceTests.cs (the Number
+// arm) for the full rationale: this is a single-value predicate evaluated
+// once for the whole query, distinct from the per-row `eachEqual` family, and
+// field-vs-literal operand shapes fail fast with NotSupportedException per
+// the ratified issue #114 contract rather than silently degrading to per-row
+// Enumerable.Contains ("IN") membership.
+[Trait("Clause", "Where")]
+[Trait("Feature", "ArrayEqualitySequence")]
+public sealed class DateArrayEqualitySequenceTests
+{
+    private static SelectExpression OrderIdSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new UuidArrayReturning(
+                    new UuidField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Id)
+                )
+            )
+        );
+    }
+
+    // Two identical literal arrays: SequenceEqual is true, so the predicate
+    // (evaluated once, applied to the whole result) keeps every row.
+    [Fact]
+    public void WholeDateArrayEqualityOfTwoEqualLiteralArraysKeepsEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new DateArrayEquality(
+                            new DateArrayReturning(
+                                new DateArrayScalar(
+                                    [
+                                        new DateOnly(2024, 1, 1),
+                                        new DateOnly(2024, 2, 1),
+                                        new DateOnly(2024, 3, 1),
+                                    ]
+                                )
+                            ),
+                            new DateArrayReturning(
+                                new DateArrayScalar(
+                                    [
+                                        new DateOnly(2024, 1, 1),
+                                        new DateOnly(2024, 2, 1),
+                                        new DateOnly(2024, 3, 1),
+                                    ]
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count, result.Count);
+    }
+
+    // Two literal arrays with the same length but a different order:
+    // SequenceEqual is false (order-sensitive), so every row is removed.
+    [Fact]
+    public void WholeDateArrayEqualityOfTwoReorderedLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new DateArrayEquality(
+                            new DateArrayReturning(
+                                new DateArrayScalar(
+                                    [
+                                        new DateOnly(2024, 1, 1),
+                                        new DateOnly(2024, 2, 1),
+                                        new DateOnly(2024, 3, 1),
+                                    ]
+                                )
+                            ),
+                            new DateArrayReturning(
+                                new DateArrayScalar(
+                                    [
+                                        new DateOnly(2024, 3, 1),
+                                        new DateOnly(2024, 2, 1),
+                                        new DateOnly(2024, 1, 1),
+                                    ]
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Two literal arrays of different lengths: SequenceEqual is false
+    // (length mismatch alone rules out equality), so every row is removed.
+    [Fact]
+    public void WholeDateArrayEqualityOfDifferentLengthLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new DateArrayEquality(
+                            new DateArrayReturning(
+                                new DateArrayScalar(
+                                    [
+                                        new DateOnly(2024, 1, 1),
+                                        new DateOnly(2024, 2, 1),
+                                        new DateOnly(2024, 3, 1),
+                                    ]
+                                )
+                            ),
+                            new DateArrayReturning(
+                                new DateArrayScalar(
+                                    [
+                                        new DateOnly(2024, 1, 1),
+                                        new DateOnly(2024, 2, 1),
+                                    ]
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Field vs. literal-array whole-array `equal` (either operand order) is
+    // not implemented as true sequence equality (see issue #114) - the
+    // translator fails fast with NotSupportedException instead of silently
+    // falling back to per-row Enumerable.Contains ("IN") membership, which
+    // would give a wrong answer here: reversing the literal doesn't change
+    // set membership, so a membership-based implementation would wrongly
+    // keep every row.
+    [Fact]
+    public void WholeDateArrayEqualityOfFieldAgainstLiteralFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        DateOnly[] reversedPlacedOn =
+        [
+            .. db.OrderRows.Select(order => order.PlacedOn).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new DateArrayEquality(
+                            new DateArrayReturning(
+                                new DateField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.PlacedOn
+                                )
+                            ),
+                            new DateArrayReturning(
+                                new DateArrayScalar(reversedPlacedOn)
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+
+    // Mirrors the test above with the operand order swapped (literal array
+    // on the left, field on the right) to cover the other arm of
+    // BuildContainmentEquality's field-vs-literal handling.
+    [Fact]
+    public void WholeDateArrayEqualityOfLiteralAgainstFieldFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        DateOnly[] reversedPlacedOn =
+        [
+            .. db.OrderRows.Select(order => order.PlacedOn).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new DateArrayEquality(
+                            new DateArrayReturning(
+                                new DateArrayScalar(reversedPlacedOn)
+                            ),
+                            new DateArrayReturning(
+                                new DateField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.PlacedOn
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/DateTimeArrayEqualitySequenceTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/DateTimeArrayEqualitySequenceTests.cs
@@ -1,0 +1,226 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayEqualities;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// DateTime arm of the whole-array `equal` (`Equality` -> `ArrayEquality`)
+// sequence-equality predicate. See ArrayEqualitySequenceTests.cs (the Number
+// arm) for the full rationale: this is a single-value predicate evaluated
+// once for the whole query, distinct from the per-row `eachEqual` family, and
+// field-vs-literal operand shapes fail fast with NotSupportedException per
+// the ratified issue #114 contract rather than silently degrading to per-row
+// Enumerable.Contains ("IN") membership.
+[Trait("Clause", "Where")]
+[Trait("Feature", "ArrayEqualitySequence")]
+public sealed class DateTimeArrayEqualitySequenceTests
+{
+    private static SelectExpression OrderIdSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new UuidArrayReturning(
+                    new UuidField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Id)
+                )
+            )
+        );
+    }
+
+    // Two identical literal arrays: SequenceEqual is true, so the predicate
+    // (evaluated once, applied to the whole result) keeps every row.
+    [Fact]
+    public void WholeDateTimeArrayEqualityOfTwoEqualLiteralArraysKeepsEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new DateTimeArrayEquality(
+                            new DateTimeArrayReturning(
+                                new DateTimeArrayScalar(
+                                    [
+                                        new DateTime(2024, 1, 1, 8, 0, 0),
+                                        new DateTime(2024, 2, 1, 9, 0, 0),
+                                        new DateTime(2024, 3, 1, 10, 0, 0),
+                                    ]
+                                )
+                            ),
+                            new DateTimeArrayReturning(
+                                new DateTimeArrayScalar(
+                                    [
+                                        new DateTime(2024, 1, 1, 8, 0, 0),
+                                        new DateTime(2024, 2, 1, 9, 0, 0),
+                                        new DateTime(2024, 3, 1, 10, 0, 0),
+                                    ]
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count, result.Count);
+    }
+
+    // Two literal arrays with the same length but a different order:
+    // SequenceEqual is false (order-sensitive), so every row is removed.
+    [Fact]
+    public void WholeDateTimeArrayEqualityOfTwoReorderedLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new DateTimeArrayEquality(
+                            new DateTimeArrayReturning(
+                                new DateTimeArrayScalar(
+                                    [
+                                        new DateTime(2024, 1, 1, 8, 0, 0),
+                                        new DateTime(2024, 2, 1, 9, 0, 0),
+                                        new DateTime(2024, 3, 1, 10, 0, 0),
+                                    ]
+                                )
+                            ),
+                            new DateTimeArrayReturning(
+                                new DateTimeArrayScalar(
+                                    [
+                                        new DateTime(2024, 3, 1, 10, 0, 0),
+                                        new DateTime(2024, 2, 1, 9, 0, 0),
+                                        new DateTime(2024, 1, 1, 8, 0, 0),
+                                    ]
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Field vs. literal-array whole-array `equal` (either operand order) is
+    // not implemented as true sequence equality (see issue #114) - the
+    // translator fails fast with NotSupportedException instead of silently
+    // falling back to per-row Enumerable.Contains ("IN") membership, which
+    // would give a wrong answer here: reversing the literal doesn't change
+    // set membership, so a membership-based implementation would wrongly
+    // keep every row.
+    [Fact]
+    public void WholeDateTimeArrayEqualityOfFieldAgainstLiteralFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        DateTime[] reversedPlacedAt =
+        [
+            .. db.OrderRows.Select(order => order.PlacedAt).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new DateTimeArrayEquality(
+                            new DateTimeArrayReturning(
+                                new DateTimeField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.PlacedAt
+                                )
+                            ),
+                            new DateTimeArrayReturning(
+                                new DateTimeArrayScalar(reversedPlacedAt)
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+
+    // Mirrors the test above with the operand order swapped (literal array
+    // on the left, field on the right) to cover the other arm of
+    // BuildContainmentEquality's field-vs-literal handling.
+    [Fact]
+    public void WholeDateTimeArrayEqualityOfLiteralAgainstFieldFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        DateTime[] reversedPlacedAt =
+        [
+            .. db.OrderRows.Select(order => order.PlacedAt).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new DateTimeArrayEquality(
+                            new DateTimeArrayReturning(
+                                new DateTimeArrayScalar(reversedPlacedAt)
+                            ),
+                            new DateTimeArrayReturning(
+                                new DateTimeField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.PlacedAt
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/StringArrayEqualitySequenceTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/StringArrayEqualitySequenceTests.cs
@@ -1,0 +1,242 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayEqualities;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// String arm of the whole-array `equal` (`Equality` -> `ArrayEquality`)
+// sequence-equality predicate. See ArrayEqualitySequenceTests.cs (the Number
+// arm) for the full rationale: this is a single-value predicate evaluated
+// once for the whole query, distinct from the per-row `eachEqual` family, and
+// field-vs-literal operand shapes fail fast with NotSupportedException per
+// the ratified issue #114 contract rather than silently degrading to per-row
+// Enumerable.Contains ("IN") membership.
+[Trait("Clause", "Where")]
+[Trait("Feature", "ArrayEqualitySequence")]
+public sealed class StringArrayEqualitySequenceTests
+{
+    private static SelectExpression OrderIdSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new UuidArrayReturning(
+                    new UuidField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Id)
+                )
+            )
+        );
+    }
+
+    // Two identical literal arrays: SequenceEqual is true, so the predicate
+    // (evaluated once, applied to the whole result) keeps every row.
+    [Fact]
+    public void WholeStringArrayEqualityOfTwoEqualLiteralArraysKeepsEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new StringArrayEquality(
+                            new StringArrayReturning(
+                                new StringArrayScalar(["alpha", "beta", "gamma"])
+                            ),
+                            new StringArrayReturning(
+                                new StringArrayScalar(["alpha", "beta", "gamma"])
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count, result.Count);
+    }
+
+    // Two literal arrays with the same length but a different order:
+    // SequenceEqual is false (order-sensitive), so every row is removed.
+    [Fact]
+    public void WholeStringArrayEqualityOfTwoReorderedLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new StringArrayEquality(
+                            new StringArrayReturning(
+                                new StringArrayScalar(["alpha", "beta", "gamma"])
+                            ),
+                            new StringArrayReturning(
+                                new StringArrayScalar(["gamma", "beta", "alpha"])
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Two literal arrays of different lengths: SequenceEqual is false
+    // (length mismatch alone rules out equality), so every row is removed.
+    [Fact]
+    public void WholeStringArrayEqualityOfDifferentLengthLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new StringArrayEquality(
+                            new StringArrayReturning(
+                                new StringArrayScalar(["alpha", "beta", "gamma"])
+                            ),
+                            new StringArrayReturning(
+                                new StringArrayScalar(
+                                    ["alpha", "beta", "gamma", "delta"]
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Field vs. literal-array whole-array `equal` (either operand order) is
+    // not implemented as true sequence equality (see issue #114) - the
+    // translator fails fast with NotSupportedException instead of silently
+    // falling back to per-row Enumerable.Contains ("IN") membership, which
+    // would give a wrong answer here: reversing the literal doesn't change
+    // set membership, so a membership-based implementation would wrongly
+    // keep every row.
+    [Fact]
+    public void WholeStringArrayEqualityOfFieldAgainstLiteralFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        string[] reversedStatuses =
+        [
+            .. db.OrderRows.Select(order => order.OrderStatus).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new StringArrayEquality(
+                            new StringArrayReturning(
+                                new StringField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Status
+                                )
+                            ),
+                            new StringArrayReturning(
+                                new StringArrayScalar(reversedStatuses)
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+
+    // Mirrors the test above with the operand order swapped (literal array
+    // on the left, field on the right) to cover the other arm of
+    // BuildContainmentEquality's field-vs-literal handling.
+    [Fact]
+    public void WholeStringArrayEqualityOfLiteralAgainstFieldFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        string[] reversedStatuses =
+        [
+            .. db.OrderRows.Select(order => order.OrderStatus).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new StringArrayEquality(
+                            new StringArrayReturning(
+                                new StringArrayScalar(reversedStatuses)
+                            ),
+                            new StringArrayReturning(
+                                new StringField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Status
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/TimeArrayEqualitySequenceTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/TimeArrayEqualitySequenceTests.cs
@@ -1,0 +1,226 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayEqualities;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// Time arm of the whole-array `equal` (`Equality` -> `ArrayEquality`)
+// sequence-equality predicate. See ArrayEqualitySequenceTests.cs (the Number
+// arm) for the full rationale: this is a single-value predicate evaluated
+// once for the whole query, distinct from the per-row `eachEqual` family, and
+// field-vs-literal operand shapes fail fast with NotSupportedException per
+// the ratified issue #114 contract rather than silently degrading to per-row
+// Enumerable.Contains ("IN") membership.
+[Trait("Clause", "Where")]
+[Trait("Feature", "ArrayEqualitySequence")]
+public sealed class TimeArrayEqualitySequenceTests
+{
+    private static SelectExpression OrderIdSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new UuidArrayReturning(
+                    new UuidField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Id)
+                )
+            )
+        );
+    }
+
+    // Two identical literal arrays: SequenceEqual is true, so the predicate
+    // (evaluated once, applied to the whole result) keeps every row.
+    [Fact]
+    public void WholeTimeArrayEqualityOfTwoEqualLiteralArraysKeepsEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new TimeArrayEquality(
+                            new TimeArrayReturning(
+                                new TimeArrayScalar(
+                                    [
+                                        new TimeOnly(8, 0, 0),
+                                        new TimeOnly(9, 0, 0),
+                                        new TimeOnly(10, 0, 0),
+                                    ]
+                                )
+                            ),
+                            new TimeArrayReturning(
+                                new TimeArrayScalar(
+                                    [
+                                        new TimeOnly(8, 0, 0),
+                                        new TimeOnly(9, 0, 0),
+                                        new TimeOnly(10, 0, 0),
+                                    ]
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count, result.Count);
+    }
+
+    // Two literal arrays with the same length but a different order:
+    // SequenceEqual is false (order-sensitive), so every row is removed.
+    [Fact]
+    public void WholeTimeArrayEqualityOfTwoReorderedLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new TimeArrayEquality(
+                            new TimeArrayReturning(
+                                new TimeArrayScalar(
+                                    [
+                                        new TimeOnly(8, 0, 0),
+                                        new TimeOnly(9, 0, 0),
+                                        new TimeOnly(10, 0, 0),
+                                    ]
+                                )
+                            ),
+                            new TimeArrayReturning(
+                                new TimeArrayScalar(
+                                    [
+                                        new TimeOnly(10, 0, 0),
+                                        new TimeOnly(9, 0, 0),
+                                        new TimeOnly(8, 0, 0),
+                                    ]
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Field vs. literal-array whole-array `equal` (either operand order) is
+    // not implemented as true sequence equality (see issue #114) - the
+    // translator fails fast with NotSupportedException instead of silently
+    // falling back to per-row Enumerable.Contains ("IN") membership, which
+    // would give a wrong answer here: reversing the literal doesn't change
+    // set membership, so a membership-based implementation would wrongly
+    // keep every row.
+    [Fact]
+    public void WholeTimeArrayEqualityOfFieldAgainstLiteralFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        TimeOnly[] reversedShiftStarts =
+        [
+            .. db.UserRows.Select(user => user.ShiftStart).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new TimeArrayEquality(
+                            new TimeArrayReturning(
+                                new TimeField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.ShiftStart
+                                )
+                            ),
+                            new TimeArrayReturning(
+                                new TimeArrayScalar(reversedShiftStarts)
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+
+    // Mirrors the test above with the operand order swapped (literal array
+    // on the left, field on the right) to cover the other arm of
+    // BuildContainmentEquality's field-vs-literal handling.
+    [Fact]
+    public void WholeTimeArrayEqualityOfLiteralAgainstFieldFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        TimeOnly[] reversedShiftStarts =
+        [
+            .. db.UserRows.Select(user => user.ShiftStart).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new TimeArrayEquality(
+                            new TimeArrayReturning(
+                                new TimeArrayScalar(reversedShiftStarts)
+                            ),
+                            new TimeArrayReturning(
+                                new TimeField(
+                                    SampleDatabase.Users.Entity,
+                                    SampleDatabase.Users.ShiftStart
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/UuidArrayEqualitySequenceTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Where/Each/UuidArrayEqualitySequenceTests.cs
@@ -1,0 +1,250 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.ArrayEqualities;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.ArrayScalars;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Where.Each;
+
+// Uuid arm of the whole-array `equal` (`Equality` -> `ArrayEquality`)
+// sequence-equality predicate. See ArrayEqualitySequenceTests.cs (the Number
+// arm) for the full rationale: this is a single-value predicate evaluated
+// once for the whole query, distinct from the per-row `eachEqual` family, and
+// field-vs-literal operand shapes fail fast with NotSupportedException per
+// the ratified issue #114 contract rather than silently degrading to per-row
+// Enumerable.Contains ("IN") membership.
+[Trait("Clause", "Where")]
+[Trait("Feature", "ArrayEqualitySequence")]
+public sealed class UuidArrayEqualitySequenceTests
+{
+    private static SelectExpression OrderIdSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new UuidArrayReturning(
+                    new UuidField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Id)
+                )
+            )
+        );
+    }
+
+    // Two identical literal arrays: SequenceEqual is true, so the predicate
+    // (evaluated once, applied to the whole result) keeps every row.
+    [Fact]
+    public void WholeUuidArrayEqualityOfTwoEqualLiteralArraysKeepsEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Guid[] threeOrderIds =
+        [
+            .. db.OrderRows.Select(order => order.OrderId).Take(3),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new UuidArrayEquality(
+                            new UuidArrayReturning(new UuidArrayScalar(threeOrderIds)),
+                            new UuidArrayReturning(new UuidArrayScalar(threeOrderIds))
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(db.OrderRows.Count, result.Count);
+    }
+
+    // Two literal arrays with the same length but a different order:
+    // SequenceEqual is false (order-sensitive), so every row is removed.
+    [Fact]
+    public void WholeUuidArrayEqualityOfTwoReorderedLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Guid[] threeOrderIds =
+        [
+            .. db.OrderRows.Select(order => order.OrderId).Take(3),
+        ];
+        Guid[] reversedThreeOrderIds = [.. threeOrderIds.Reverse()];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new UuidArrayEquality(
+                            new UuidArrayReturning(new UuidArrayScalar(threeOrderIds)),
+                            new UuidArrayReturning(
+                                new UuidArrayScalar(reversedThreeOrderIds)
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Two literal arrays of different lengths: SequenceEqual is false
+    // (length mismatch alone rules out equality), so every row is removed.
+    [Fact]
+    public void WholeUuidArrayEqualityOfDifferentLengthLiteralArraysRemovesEveryRow()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Guid[] threeOrderIds =
+        [
+            .. db.OrderRows.Select(order => order.OrderId).Take(3),
+        ];
+        Guid[] twoOrderIds =
+        [
+            .. db.OrderRows.Select(order => order.OrderId).Take(2),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new UuidArrayEquality(
+                            new UuidArrayReturning(new UuidArrayScalar(threeOrderIds)),
+                            new UuidArrayReturning(new UuidArrayScalar(twoOrderIds))
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Assert.Equal(0, result.Count);
+    }
+
+    // Field vs. literal-array whole-array `equal` (either operand order) is
+    // not implemented as true sequence equality (see issue #114) - the
+    // translator fails fast with NotSupportedException instead of silently
+    // falling back to per-row Enumerable.Contains ("IN") membership, which
+    // would give a wrong answer here: reversing the literal doesn't change
+    // set membership, so a membership-based implementation would wrongly
+    // keep every row.
+    [Fact]
+    public void WholeUuidArrayEqualityOfFieldAgainstLiteralFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Guid[] reversedOrderIds =
+        [
+            .. db.OrderRows.Select(order => order.OrderId).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new UuidArrayEquality(
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Id
+                                )
+                            ),
+                            new UuidArrayReturning(
+                                new UuidArrayScalar(reversedOrderIds)
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+
+    // Mirrors the test above with the operand order swapped (literal array
+    // on the left, field on the right) to cover the other arm of
+    // BuildContainmentEquality's field-vs-literal handling.
+    [Fact]
+    public void WholeUuidArrayEqualityOfLiteralAgainstFieldFailsFast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Guid[] reversedOrderIds =
+        [
+            .. db.OrderRows.Select(order => order.OrderId).Reverse(),
+        ];
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [OrderIdSelect()],
+            new BooleanReturning(
+                new Equality(
+                    new ArrayEquality(
+                        new UuidArrayEquality(
+                            new UuidArrayReturning(
+                                new UuidArrayScalar(reversedOrderIds)
+                            ),
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Id
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            join: null,
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+}


### PR DESCRIPTION
## Summary

Extends the whole-array `equal` (`Equality` -> `ArrayEquality`) sequence-equality
coverage from the single existing `NumberArrayEquality` arm
(`Where/Each/ArrayEqualitySequenceTests.cs`, left untouched) to the six
remaining element types, one new file per type in `Where/Each/`:

- `BooleanArrayEqualitySequenceTests.cs`
- `DateArrayEqualitySequenceTests.cs`
- `DateTimeArrayEqualitySequenceTests.cs`
- `StringArrayEqualitySequenceTests.cs`
- `TimeArrayEqualitySequenceTests.cs`
- `UuidArrayEqualitySequenceTests.cs`

27 new tests (31 total in the `ArrayEqualitySequence` feature after this
change). Each type gets the four base cases from the existing Number file:

1. Two equal literal arrays -> `SequenceEqual` true -> keeps every row.
2. Same elements, different order -> `SequenceEqual` false (order-sensitive)
   -> zero rows.
3. Field vs. literal array -> `NotSupportedException` (ratified #114
   contract: the translator refuses rather than silently degrading to
   per-row `Contains`/`IN` membership, which would be wrong here).
4. Literal array vs. field (operand order swapped) -> also
   `NotSupportedException`.

Plus a fifth different-length-literal-arrays case (`SequenceEqual` false on
length alone) added to three types (Date, String, Uuid) for a bit of extra
breadth beyond the "at least a couple" ask.

Fields used for the field-vs-literal cases match the issue's suggestions:
`Products.InStock` (Boolean), `Orders.PlacedOn` (Date), `Orders.PlacedAt`
(DateTime), `Orders.Status` (String), `Users.ShiftStart` (Time),
`Orders.Id` (Uuid).

## SQL-semantics decisions

- The literal-vs-literal cases assert true SQL sequence-equality semantics
  (order- and length-sensitive), independently computed, never bent toward
  the translator's current behaviour.
- The field-vs-literal cases assert the fail-fast `NotSupportedException`
  as the *correct* current contract (per the ratified #114 decision), not a
  softened workaround — these are real asserting tests, not `KnownGap`
  skips.
- No `KnownGap` skips were needed for this issue.

## Verification

From `./src`: `dotnet build --no-restore -warnaserror`, `dotnet format
--verify-no-changes`, and `dotnet test --no-build --filter
"Status!=KnownGap"` all pass (412/412 total, 31/31 in the
`ArrayEqualitySequence` feature).

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)