### PR TITLE
Test combos: join type x full downstream pipeline

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinPipelineFullStackTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinPipelineFullStackTests.cs
@@ -1,0 +1,502 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+using ModelPagination = PureQL.CSharp.Model.Pagination;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+// Every clause at once, layered on each JoinType in turn: JOIN -> WHERE ->
+// GROUP BY -> HAVING -> ORDER BY -> DISTINCT -> pagination. Extends
+// Combined/FullPipelineTests.cs (INNER JOIN only) to LEFT/RIGHT/FULL, and
+// adds a cross-schema variant against audit.logins for breadth.
+//
+// Selecting only the aggregate (no group key in the output) makes DISTINCT
+// do real work here: Ann and Cara both place 2 orders, so their projected
+// group rows (orderCount = 2) collapse into a single distinct row once
+// DISTINCT runs, alongside Dan's (orderCount = 1). Fay (active, but no
+// orders) forms its own zero-count group, which HAVING then drops - so the
+// outer-join-only "empty group" case is exercised here too.
+[Trait("Clause", "Join")]
+[Trait("Feature", "JoinPipelineCombo")]
+public sealed class JoinPipelineFullStackTests
+{
+    private static Join UsersToOrdersInnerJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Orders.Entity,
+            UsersOrdersCondition()
+        );
+    }
+
+    private static Join UsersToOrdersLeftJoin()
+    {
+        return new Join(JoinType.Left, SampleDatabase.Orders.Entity, UsersOrdersCondition());
+    }
+
+    private static Join OrdersToUsersRightJoin()
+    {
+        return new Join(
+            JoinType.Right,
+            SampleDatabase.Users.Entity,
+            OrdersUsersCondition()
+        );
+    }
+
+    private static Join OrdersToUsersFullJoin()
+    {
+        return new Join(JoinType.Full, SampleDatabase.Users.Entity, OrdersUsersCondition());
+    }
+
+    private static BooleanArrayReturning UsersOrdersCondition()
+    {
+        return new BooleanArrayReturning(
+            new EachEquality(
+                new EachUuidEquality(
+                    new UuidArrayReturning(
+                        new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+                    ),
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.UserId
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static BooleanArrayReturning OrdersUsersCondition()
+    {
+        return new BooleanArrayReturning(
+            new EachEquality(
+                new EachUuidEquality(
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.UserId
+                        )
+                    ),
+                    new UuidArrayReturning(
+                        new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+                    )
+                )
+            )
+        );
+    }
+
+    private static BooleanArrayReturning UserIsActiveEach()
+    {
+        return new BooleanArrayReturning(
+            new EachEquality(
+                new EachBooleanEquality(
+                    new BooleanArrayReturning(
+                        new BooleanField(
+                            SampleDatabase.Users.Entity,
+                            SampleDatabase.Users.Active
+                        )
+                    ),
+                    new BooleanReturning(new BooleanScalar(true))
+                )
+            )
+        );
+    }
+
+    private static SelectExpression OrderCountSelect()
+    {
+        return new SelectExpression(
+            new SingleValueReturning(
+                new NumberReturning(
+                    new Count(
+                        new ArrayReturning(
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Id
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            "orderCount"
+        );
+    }
+
+    private static BooleanReturning CountAtLeastOne()
+    {
+        return new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    ComparisonOperator.GreaterThanOrEqual,
+                    new NumberReturning(
+                        new NumberAggregate(
+                            new SumNumber(
+                                new NumberArrayReturning(
+                                    new NumberField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.Total
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(0))
+                )
+            )
+        );
+    }
+
+    // sum(total) >= 0 is only ever true when the group actually has a
+    // matched order (an empty/NULL group folds sum to NULL, and NULL >= 0
+    // is unknown), so this HAVING clause is a clean, aggregate-driven way
+    // to require "at least one order" without a bare count comparison.
+    private static Query FullPipelineQuery(FromExpression from, Join join)
+    {
+        return new Query(
+            from,
+            [OrderCountSelect()],
+            UserIsActiveEach(),
+            [join],
+            [
+                new Field(
+                    new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+                ),
+            ],
+            CountAtLeastOne(),
+            [
+                new OrderByItem(
+                    new Field(
+                        new NumberField(SampleDatabase.Users.Entity, "orderCount")
+                    ),
+                    SortDirection.Desc
+                ),
+            ],
+            new ModelPagination(1, 5),
+            distinct: true
+        );
+    }
+
+    // Active users are Ann, Cara, Dan, Fay (Bob and Eve are inactive and
+    // dropped by WHERE). Ann and Cara each place 2 orders, Dan places 1,
+    // and Fay places none - Fay's zero-order group is dropped by HAVING.
+    // Distinct group counts, sorted desc, are therefore [2, 1]; skipping
+    // the first (2) and taking up to 5 leaves exactly [1].
+    private static double[] ExpectedDistinctOrderCountsSkippingFirst(SampleDatabase db)
+    {
+        return
+        [
+            .. db.UserRows
+                .Where(user => user.UserActive)
+                .Select(user =>
+                    (double)db.OrderRows.Count(order => order.OrderUserId == user.UserId)
+                )
+                .Where(count => count >= 1)
+                .Distinct()
+                .OrderByDescending(count => count)
+                .Skip(1)
+                .Take(5),
+        ];
+    }
+
+    [Fact]
+    public void InnerJoinFullPipelineComposesEveryClauseInOrder()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = FullPipelineQuery(
+            new FromExpression(SampleDatabase.Users.Entity),
+            UsersToOrdersInnerJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double[] expected = ExpectedDistinctOrderCountsSkippingFirst(db);
+
+        double[] actual = [.. result.Rows.Select(row => row.Double("orderCount")!.Value)];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void LeftJoinFullPipelineComposesEveryClauseInOrder()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = FullPipelineQuery(
+            new FromExpression(SampleDatabase.Users.Entity),
+            UsersToOrdersLeftJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double[] expected = ExpectedDistinctOrderCountsSkippingFirst(db);
+
+        double[] actual = [.. result.Rows.Select(row => row.Double("orderCount")!.Value)];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void RightJoinFullPipelineComposesEveryClauseInOrder()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = FullPipelineQuery(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            OrdersToUsersRightJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double[] expected = ExpectedDistinctOrderCountsSkippingFirst(db);
+
+        double[] actual = [.. result.Rows.Select(row => row.Double("orderCount")!.Value)];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void FullJoinFullPipelineComposesEveryClauseInOrder()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = FullPipelineQuery(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            OrdersToUsersFullJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double[] expected = ExpectedDistinctOrderCountsSkippingFirst(db);
+
+        double[] actual = [.. result.Rows.Select(row => row.Double("orderCount")!.Value)];
+
+        Assert.Equal(expected, actual);
+    }
+
+    // Cross-schema breadth: shop.users <-> audit.logins. Ann has 2 logins,
+    // Bob and Eve have 1 each, Cara/Dan/Fay have none. WHERE keeps every
+    // row (bare true), GROUP BY the user, HAVING requires at least one
+    // login, ORDER BY the count desc, DISTINCT collapses Bob's and Eve's
+    // tied count of 1 into a single row alongside Ann's 2, and pagination
+    // takes just the top entry.
+    [Fact]
+    public void CrossSchemaLeftJoinFullPipelineComposesEveryClauseInOrder()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Join usersToLoginsLeftJoin = new Join(
+            JoinType.Left,
+            SampleDatabase.Logins.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Logins.Entity,
+                                SampleDatabase.Logins.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Logins.Entity,
+                                            SampleDatabase.Logins.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "loginCount"
+                ),
+            ],
+            where: null,
+            [usersToLoginsLeftJoin],
+            [
+                new Field(
+                    new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+                ),
+            ],
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.GreaterThanOrEqual,
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Logins.Entity,
+                                            SampleDatabase.Logins.Id
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        new NumberReturning(new NumberScalar(1))
+                    )
+                )
+            ),
+            [
+                new OrderByItem(
+                    new Field(
+                        new NumberField(SampleDatabase.Users.Entity, "loginCount")
+                    ),
+                    SortDirection.Desc
+                ),
+            ],
+            new ModelPagination(0, 1),
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double[] expected =
+        [
+            .. db.UserRows
+                .Select(user =>
+                    (double)db.LoginRows.Count(login => login.LoginUserId == user.UserId)
+                )
+                .Where(count => count >= 1)
+                .Distinct()
+                .OrderByDescending(count => count)
+                .Take(1),
+        ];
+
+        double[] actual = [.. result.Rows.Select(row => row.Double("loginCount")!.Value)];
+
+        Assert.Equal(expected, actual);
+    }
+
+    // Cross-schema variant with an INNER JOIN: every emitted group already
+    // has at least one login by construction, so HAVING is a pass-through
+    // and the interesting behaviour is DISTINCT collapsing Bob's and Eve's
+    // tied login count after ORDER BY + pagination select the full set.
+    [Fact]
+    public void CrossSchemaInnerJoinFullPipelineComposesEveryClauseInOrder()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Join usersToLoginsInnerJoin = new Join(
+            JoinType.Inner,
+            SampleDatabase.Logins.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Logins.Entity,
+                                SampleDatabase.Logins.UserId
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Logins.Entity,
+                                            SampleDatabase.Logins.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "loginCount"
+                ),
+            ],
+            where: null,
+            [usersToLoginsInnerJoin],
+            [
+                new Field(
+                    new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+                ),
+            ],
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new NumberField(SampleDatabase.Users.Entity, "loginCount")
+                    ),
+                    SortDirection.Desc
+                ),
+            ],
+            new ModelPagination(0, 5),
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double[] expected =
+        [
+            .. db.UserRows
+                .Select(user =>
+                    (double)db.LoginRows.Count(login => login.LoginUserId == user.UserId)
+                )
+                .Where(count => count >= 1)
+                .Distinct()
+                .OrderByDescending(count => count)
+                .Take(5),
+        ];
+
+        double[] actual = [.. result.Rows.Select(row => row.Double("loginCount")!.Value)];
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinPipelineOrderDistinctPaginationTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinPipelineOrderDistinctPaginationTests.cs
@@ -1,0 +1,635 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using ModelPagination = PureQL.CSharp.Model.Pagination;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+// Matrix: each JoinType layered with ORDER BY (including the ratified
+// NULLS-last rule for the outer-joined side), DISTINCT (collapsing join
+// fan-out, including padded rows), and ORDER BY + pagination windowing.
+[Trait("Clause", "Join")]
+[Trait("Feature", "JoinPipelineCombo")]
+public sealed class JoinPipelineOrderDistinctPaginationTests
+{
+    private static Join UsersToOrdersLeftJoin()
+    {
+        return new Join(JoinType.Left, SampleDatabase.Orders.Entity, UsersOrdersCondition());
+    }
+
+    private static Join OrdersToUsersRightJoin()
+    {
+        return new Join(
+            JoinType.Right,
+            SampleDatabase.Users.Entity,
+            OrdersUsersCondition()
+        );
+    }
+
+    private static Join OrdersToUsersFullJoin()
+    {
+        return new Join(JoinType.Full, SampleDatabase.Users.Entity, OrdersUsersCondition());
+    }
+
+    private static Join UsersToOrdersInnerJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Orders.Entity,
+            UsersOrdersCondition()
+        );
+    }
+
+    private static BooleanArrayReturning UsersOrdersCondition()
+    {
+        return new BooleanArrayReturning(
+            new EachEquality(
+                new EachUuidEquality(
+                    new UuidArrayReturning(
+                        new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+                    ),
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.UserId
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static BooleanArrayReturning OrdersUsersCondition()
+    {
+        return new BooleanArrayReturning(
+            new EachEquality(
+                new EachUuidEquality(
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.UserId
+                        )
+                    ),
+                    new UuidArrayReturning(
+                        new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+                    )
+                )
+            )
+        );
+    }
+
+    private static SelectExpression UserNameSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new StringArrayReturning(
+                    new StringField(SampleDatabase.Users.Entity, SampleDatabase.Users.Name)
+                )
+            )
+        );
+    }
+
+    private static SelectExpression OrderTotalSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new NumberArrayReturning(
+                    new NumberField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Total)
+                )
+            )
+        );
+    }
+
+    private static OrderByItem OrderByTotalAsc()
+    {
+        return new OrderByItem(
+            new Field(
+                new NumberField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Total)
+            ),
+            SortDirection.Asc
+        );
+    }
+
+    private static OrderByItem OrderByTotalDesc()
+    {
+        return new OrderByItem(
+            new Field(
+                new NumberField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Total)
+            ),
+            SortDirection.Desc
+        );
+    }
+
+    private static OrderByItem OrderByNameAsc()
+    {
+        return new OrderByItem(
+            new Field(
+                new StringField(SampleDatabase.Users.Entity, SampleDatabase.Users.Name)
+            ),
+            SortDirection.Asc
+        );
+    }
+
+    // (name, total) pairs for every user, LEFT-JOIN style: matched users
+    // appear once per order, unmatched users appear once with a NULL total.
+    // Ties on total are broken by name so the expected sequence is fully
+    // deterministic without depending on the translator's tie-break/stable-
+    // sort behaviour matching this computation by coincidence.
+    private static List<(string Name, double? Total)> LeftOuterPairs(SampleDatabase db)
+    {
+        return
+        [
+            .. from user in db.UserRows
+                join order in db.OrderRows on user.UserId equals order.OrderUserId into g
+                from order in g.DefaultIfEmpty()
+                select (user.UserName, order?.OrderTotal),
+        ];
+    }
+
+    [Fact]
+    public void LeftJoinOrderByJoinedTotalAscendingSortsNullsLast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [UserNameSelect(), OrderTotalSelect()],
+            where: null,
+            [UsersToOrdersLeftJoin()],
+            groupBy: null,
+            having: null,
+            [OrderByTotalAsc(), OrderByNameAsc()],
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string, double?)[] expected =
+        [
+            .. LeftOuterPairs(db)
+                .OrderBy(pair => pair.Total.HasValue ? 0 : 1)
+                .ThenBy(pair => pair.Total)
+                .ThenBy(pair => pair.Name, StringComparer.Ordinal),
+        ];
+
+        (string, double?)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (row[SampleDatabase.Users.Name]!, row.Double(SampleDatabase.Orders.Total))
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void RightJoinOrderByJoinedTotalAscendingSortsNullsLast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [UserNameSelect(), OrderTotalSelect()],
+            where: null,
+            [OrdersToUsersRightJoin()],
+            groupBy: null,
+            having: null,
+            [OrderByTotalAsc(), OrderByNameAsc()],
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string, double?)[] expected =
+        [
+            .. LeftOuterPairs(db)
+                .OrderBy(pair => pair.Total.HasValue ? 0 : 1)
+                .ThenBy(pair => pair.Total)
+                .ThenBy(pair => pair.Name, StringComparer.Ordinal),
+        ];
+
+        (string, double?)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (row[SampleDatabase.Users.Name]!, row.Double(SampleDatabase.Orders.Total))
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void FullJoinOrderByJoinedTotalDescendingStillSortsNullsLast()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [UserNameSelect(), OrderTotalSelect()],
+            where: null,
+            [OrdersToUsersFullJoin()],
+            groupBy: null,
+            having: null,
+            [OrderByTotalDesc(), OrderByNameAsc()],
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        // NULLS-last is unconditional: even under a descending primary
+        // sort, the unmatched rows (NULL total) still land at the end.
+        (string, double?)[] expected =
+        [
+            .. LeftOuterPairs(db)
+                .OrderBy(pair => pair.Total.HasValue ? 0 : 1)
+                .ThenByDescending(pair => pair.Total)
+                .ThenBy(pair => pair.Name, StringComparer.Ordinal),
+        ];
+
+        (string, double?)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (row[SampleDatabase.Users.Name]!, row.Double(SampleDatabase.Orders.Total))
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    // ORDER BY the aggregate alias in group mode, on top of a LEFT JOIN:
+    // proves the alias sort runs against the post-aggregation row (per
+    // RowsFromDatasets.Build) even when the underlying rows came from an
+    // outer join.
+    [Fact]
+    public void LeftJoinGroupByOrderByAggregateAliasDescendingOrdersGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                UserNameSelect(),
+                new SelectExpression(
+                    new SingleValueReturning(
+                        new NumberReturning(
+                            new Count(
+                                new ArrayReturning(
+                                    new UuidArrayReturning(
+                                        new UuidField(
+                                            SampleDatabase.Orders.Entity,
+                                            SampleDatabase.Orders.Id
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    "orderCount"
+                ),
+            ],
+            where: null,
+            [UsersToOrdersLeftJoin()],
+            [
+                new Field(
+                    new StringField(
+                        SampleDatabase.Users.Entity,
+                        SampleDatabase.Users.Name
+                    )
+                ),
+            ],
+            having: null,
+            [
+                new OrderByItem(
+                    new Field(
+                        new NumberField(SampleDatabase.Orders.Entity, "orderCount")
+                    ),
+                    SortDirection.Desc
+                ),
+                OrderByNameAsc(),
+            ],
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string, double)[] expected =
+        [
+            .. db.UserRows
+                .Select(user =>
+                    (
+                        user.UserName,
+                        (double)db.OrderRows.Count(order => order.OrderUserId == user.UserId)
+                    )
+                )
+                .OrderByDescending(pair => pair.Item2)
+                .ThenBy(pair => pair.UserName, StringComparer.Ordinal),
+        ];
+
+        (string, double)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (row[SampleDatabase.Users.Name]!, row.Double("orderCount")!.Value)
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    // SELECT DISTINCT users.name through an outer join: unlike an INNER
+    // JOIN (Select/DistinctOverJoinTests), the padded rows for unmatched
+    // users still carry their own real name, so DISTINCT must keep every
+    // user, not just the ones with at least one order.
+    private static Query DistinctUserNames(FromExpression from, Join join)
+    {
+        return new Query(
+            from,
+            [UserNameSelect()],
+            where: null,
+            [join],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+    }
+
+    [Fact]
+    public void LeftJoinDistinctOnUserNameKeepsEveryUserIncludingUnmatched()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = DistinctUserNames(
+            new FromExpression(SampleDatabase.Users.Entity),
+            UsersToOrdersLeftJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.UserRows.Select(user => user.UserName).Distinct().OrderBy(name => name),
+        ];
+
+        Assert.Equal(
+            expected,
+            result.Column(SampleDatabase.Users.Name).OrderBy(name => name).ToArray()
+        );
+    }
+
+    [Fact]
+    public void RightJoinDistinctOnUserNameKeepsEveryUserIncludingUnmatched()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = DistinctUserNames(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            OrdersToUsersRightJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.UserRows.Select(user => user.UserName).Distinct().OrderBy(name => name),
+        ];
+
+        Assert.Equal(
+            expected,
+            result.Column(SampleDatabase.Users.Name).OrderBy(name => name).ToArray()
+        );
+    }
+
+    [Fact]
+    public void FullJoinDistinctOnUserNameKeepsEveryUserIncludingUnmatched()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = DistinctUserNames(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            OrdersToUsersFullJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.UserRows.Select(user => user.UserName).Distinct().OrderBy(name => name),
+        ];
+
+        Assert.Equal(
+            expected,
+            result.Column(SampleDatabase.Users.Name).OrderBy(name => name).ToArray()
+        );
+    }
+
+    // DISTINCT on the padded (joined) side itself: the ratified rule pads
+    // a missing string cell with "" (Semantics/README.md), so the distinct
+    // value set for orders.status through a LEFT JOIN gains an extra ""
+    // entry on top of the three real statuses, for the two unmatched users.
+    [Fact]
+    public void LeftJoinDistinctOnJoinedStatusIncludesEmptyStringForPaddedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new StringArrayReturning(
+                            new StringField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Status
+                            )
+                        )
+                    )
+                ),
+            ],
+            where: null,
+            [UsersToOrdersLeftJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null,
+            distinct: true
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected =
+        [
+            .. db.OrderRows
+                .Select(order => order.OrderStatus)
+                .Append(string.Empty)
+                .Distinct()
+                .OrderBy(status => status, StringComparer.Ordinal),
+        ];
+
+        Assert.Equal(
+            expected,
+            result
+                .Column(SampleDatabase.Orders.Status)
+                .OrderBy(status => status, StringComparer.Ordinal)
+                .ToArray()
+        );
+    }
+
+    // ORDER BY + pagination windowing over the joined rows. The window
+    // (skip 2, take 3) lands entirely on matched rows for every join type
+    // in this fixture (the NULL-total padded rows sort last, past the
+    // window), so all four join types share the same expected slice.
+    private static (string Name, double Total)[] ExpectedInnerWindow(SampleDatabase db)
+    {
+        return
+        [
+            .. (
+                from user in db.UserRows
+                join order in db.OrderRows on user.UserId equals order.OrderUserId
+                select (user.UserName, order.OrderTotal)
+            )
+                .OrderBy(pair => pair.OrderTotal)
+                .ThenBy(pair => pair.UserName, StringComparer.Ordinal)
+                .Skip(2)
+                .Take(3),
+        ];
+    }
+
+    private static Query WindowedQuery(FromExpression from, Join join)
+    {
+        return new Query(
+            from,
+            [UserNameSelect(), OrderTotalSelect()],
+            where: null,
+            [join],
+            groupBy: null,
+            having: null,
+            [OrderByTotalAsc(), OrderByNameAsc()],
+            new ModelPagination(2, 3)
+        );
+    }
+
+    [Fact]
+    public void InnerJoinOrderByThenPaginationWindowsJoinedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = WindowedQuery(
+            new FromExpression(SampleDatabase.Users.Entity),
+            UsersToOrdersInnerJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string, double)[] expected = ExpectedInnerWindow(db);
+
+        (string, double)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (row[SampleDatabase.Users.Name]!, row.Double(SampleDatabase.Orders.Total)!.Value)
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void LeftJoinOrderByThenPaginationWindowsJoinedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = WindowedQuery(
+            new FromExpression(SampleDatabase.Users.Entity),
+            UsersToOrdersLeftJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string, double)[] expected = ExpectedInnerWindow(db);
+
+        (string, double)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (row[SampleDatabase.Users.Name]!, row.Double(SampleDatabase.Orders.Total)!.Value)
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void RightJoinOrderByThenPaginationWindowsJoinedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = WindowedQuery(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            OrdersToUsersRightJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string, double)[] expected = ExpectedInnerWindow(db);
+
+        (string, double)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (row[SampleDatabase.Users.Name]!, row.Double(SampleDatabase.Orders.Total)!.Value)
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void FullJoinOrderByThenPaginationWindowsJoinedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = WindowedQuery(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            OrdersToUsersFullJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        (string, double)[] expected = ExpectedInnerWindow(db);
+
+        (string, double)[] actual =
+        [
+            .. result.Rows.Select(row =>
+                (row[SampleDatabase.Users.Name]!, row.Double(SampleDatabase.Orders.Total)!.Value)
+            ),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinPipelineWhereHavingTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Joins/JoinPipelineWhereHavingTests.cs
@@ -1,0 +1,593 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.EachComparisons;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Joins;
+
+// Matrix: each JoinType (Inner/Left/Right/Full) layered with WHERE and with
+// GROUP BY + HAVING on top of the joined rows. Expectations are computed
+// independently with GroupJoin/DefaultIfEmpty so outer-join padded rows are
+// modelled the way SQL would (NULL on the unmatched side; a numeric/uuid
+// comparison against NULL is unknown and drops the row from WHERE/HAVING).
+[Trait("Clause", "Join")]
+[Trait("Feature", "JoinPipelineCombo")]
+public sealed class JoinPipelineWhereHavingTests
+{
+    private static Join UsersToOrdersInnerJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Orders.Entity,
+            UsersOrdersCondition()
+        );
+    }
+
+    private static Join UsersToOrdersLeftJoin()
+    {
+        return new Join(JoinType.Left, SampleDatabase.Orders.Entity, UsersOrdersCondition());
+    }
+
+    private static Join OrdersToUsersRightJoin()
+    {
+        return new Join(
+            JoinType.Right,
+            SampleDatabase.Users.Entity,
+            OrdersUsersCondition()
+        );
+    }
+
+    private static Join OrdersToUsersFullJoin()
+    {
+        return new Join(JoinType.Full, SampleDatabase.Users.Entity, OrdersUsersCondition());
+    }
+
+    private static BooleanArrayReturning UsersOrdersCondition()
+    {
+        return new BooleanArrayReturning(
+            new EachEquality(
+                new EachUuidEquality(
+                    new UuidArrayReturning(
+                        new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+                    ),
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.UserId
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    private static BooleanArrayReturning OrdersUsersCondition()
+    {
+        return new BooleanArrayReturning(
+            new EachEquality(
+                new EachUuidEquality(
+                    new UuidArrayReturning(
+                        new UuidField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.UserId
+                        )
+                    ),
+                    new UuidArrayReturning(
+                        new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+                    )
+                )
+            )
+        );
+    }
+
+    private static BooleanArrayReturning TotalAtLeast100Each()
+    {
+        return new BooleanArrayReturning(
+            new EachComparison(
+                new EachNumberComparison(
+                    EachComparisonOperator.EachGreaterThanOrEqual,
+                    new NumberArrayReturning(
+                        new NumberField(
+                            SampleDatabase.Orders.Entity,
+                            SampleDatabase.Orders.Total
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(100))
+                )
+            )
+        );
+    }
+
+    private static SelectExpression UserNameSelect()
+    {
+        return new SelectExpression(
+            new ArrayReturning(
+                new StringArrayReturning(
+                    new StringField(SampleDatabase.Users.Entity, SampleDatabase.Users.Name)
+                )
+            )
+        );
+    }
+
+    // Every order with total >= 100, independent of unmatched-row padding:
+    // Ann/101, Bob/103, Cara/105, Dan/106 survive; Ann/102 (50) and
+    // Cara/104 (75.25) do not.
+    private static string[] ExpectedNamesWithTotalAtLeast100(SampleDatabase db)
+    {
+        return
+        [
+            .. db.OrderRows
+                .Where(order => order.OrderTotal >= 100)
+                .Select(order =>
+                    db.UserRows.Single(user => user.UserId == order.OrderUserId).UserName
+                )
+                .OrderBy(name => name, StringComparer.Ordinal),
+        ];
+    }
+
+    [Fact]
+    public void InnerJoinThenEachWhereOnJoinedTotalKeepsOnlyQualifyingOrders()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [UserNameSelect()],
+            TotalAtLeast100Each(),
+            [UsersToOrdersInnerJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected = ExpectedNamesWithTotalAtLeast100(db);
+
+        string?[] actual =
+        [
+            .. result.Column(SampleDatabase.Users.Name).OrderBy(name => name),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void LeftJoinThenEachWhereOnJoinedTotalExcludesUnmatchedPaddedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [UserNameSelect()],
+            TotalAtLeast100Each(),
+            [UsersToOrdersLeftJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        // The padded rows for Eve/Fay carry a NULL total; NULL >= 100 is
+        // unknown in SQL, so WHERE drops them exactly like every real row
+        // that fails the threshold.
+        string[] expected = ExpectedNamesWithTotalAtLeast100(db);
+
+        string?[] actual =
+        [
+            .. result.Column(SampleDatabase.Users.Name).OrderBy(name => name),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void RightJoinThenEachWhereOnJoinedTotalExcludesUnmatchedPaddedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [UserNameSelect()],
+            TotalAtLeast100Each(),
+            [OrdersToUsersRightJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected = ExpectedNamesWithTotalAtLeast100(db);
+
+        string?[] actual =
+        [
+            .. result.Column(SampleDatabase.Users.Name).OrderBy(name => name),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void FullJoinThenEachWhereOnJoinedTotalExcludesUnmatchedPaddedRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [UserNameSelect()],
+            TotalAtLeast100Each(),
+            [OrdersToUsersFullJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        string[] expected = ExpectedNamesWithTotalAtLeast100(db);
+
+        string?[] actual =
+        [
+            .. result.Column(SampleDatabase.Users.Name).OrderBy(name => name),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    private static SelectExpression OrderCountSelect(string alias)
+    {
+        return new SelectExpression(
+            new SingleValueReturning(
+                new NumberReturning(
+                    new Count(
+                        new ArrayReturning(
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Id
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            alias
+        );
+    }
+
+    private static SelectExpression OrderTotalSumSelect(string alias)
+    {
+        return new SelectExpression(
+            new SingleValueReturning(
+                new NumberReturning(
+                    new NumberAggregate(
+                        new SumNumber(
+                            new NumberArrayReturning(
+                                new NumberField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Total
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            alias
+        );
+    }
+
+    private static Field UsersIdField()
+    {
+        return new Field(
+            new UuidField(SampleDatabase.Users.Entity, SampleDatabase.Users.Id)
+        );
+    }
+
+    // Extends OuterJoinAggregationTests (LEFT JOIN only) to RIGHT JOIN: an
+    // unmatched right-side user still forms its own group with a real key
+    // and a zero/NULL aggregate, exercising JoinApplicator.RightJoin's own
+    // padding branch rather than LeftJoin's.
+    [Fact]
+    public void RightJoinGroupByUserCountsZeroAndSumsNullForUnmatchedUsers()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                ),
+                OrderCountSelect("orderCount"),
+                OrderTotalSumSelect("totalSum"),
+            ],
+            where: null,
+            [OrdersToUsersRightJoin()],
+            [UsersIdField()],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, (double Count, double? Sum)> expected = db.UserRows.ToDictionary(
+            user => user.UserId,
+            user =>
+            {
+                List<OrderRow> matched =
+                [
+                    .. db.OrderRows.Where(order => order.OrderUserId == user.UserId),
+                ];
+                return (
+                    (double)matched.Count,
+                    matched.Count == 0
+                        ? (double?)null
+                        : matched.Sum(order => order.OrderTotal)
+                );
+            }
+        );
+
+        Dictionary<Guid, (double Count, double? Sum)> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Users.Id)!.Value,
+            row => (row.Double("orderCount")!.Value, row.Double("totalSum"))
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    // Same as above but for FULL JOIN, exercising JoinApplicator.FullJoin's
+    // right-unmatched padding branch.
+    [Fact]
+    public void FullJoinGroupByUserCountsZeroAndSumsNullForUnmatchedUsers()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                ),
+                OrderCountSelect("orderCount"),
+                OrderTotalSumSelect("totalSum"),
+            ],
+            where: null,
+            [OrdersToUsersFullJoin()],
+            [UsersIdField()],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, (double Count, double? Sum)> expected = db.UserRows.ToDictionary(
+            user => user.UserId,
+            user =>
+            {
+                List<OrderRow> matched =
+                [
+                    .. db.OrderRows.Where(order => order.OrderUserId == user.UserId),
+                ];
+                return (
+                    (double)matched.Count,
+                    matched.Count == 0
+                        ? (double?)null
+                        : matched.Sum(order => order.OrderTotal)
+                );
+            }
+        );
+
+        Dictionary<Guid, (double Count, double? Sum)> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Users.Id)!.Value,
+            row => (row.Double("orderCount")!.Value, row.Double("totalSum"))
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    // GROUP BY + HAVING(sum) on top of the join: Ann/Bob/Cara's sums clear
+    // the 150 bar, Dan's (100.50) does not, and unmatched users' NULL sum
+    // is unknown against ">= 150" so they are excluded exactly like Dan.
+    private static HashSet<Guid> ExpectedUsersWithTotalAtLeast150(SampleDatabase db)
+    {
+        return
+        [
+            .. db.UserRows
+                .Where(user =>
+                    db.OrderRows.Any(order => order.OrderUserId == user.UserId)
+                    && db.OrderRows
+                        .Where(order => order.OrderUserId == user.UserId)
+                        .Sum(order => order.OrderTotal)
+                        >= 150
+                )
+                .Select(user => user.UserId),
+        ];
+    }
+
+    private static BooleanReturning SumAtLeast150()
+    {
+        return new BooleanReturning(
+            new Comparison(
+                new NumberComparison(
+                    ComparisonOperator.GreaterThanOrEqual,
+                    new NumberReturning(
+                        new NumberAggregate(
+                            new SumNumber(
+                                new NumberArrayReturning(
+                                    new NumberField(
+                                        SampleDatabase.Orders.Entity,
+                                        SampleDatabase.Orders.Total
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    new NumberReturning(new NumberScalar(150))
+                )
+            )
+        );
+    }
+
+    private static Query GroupedByUserWithHaving(FromExpression from, Join join)
+    {
+        return new Query(
+            from,
+            [
+                new SelectExpression(
+                    new ArrayReturning(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                ),
+                OrderTotalSumSelect("totalSum"),
+            ],
+            where: null,
+            [join],
+            [UsersIdField()],
+            SumAtLeast150(),
+            orderBy: null,
+            pagination: null
+        );
+    }
+
+    [Fact]
+    public void InnerJoinGroupByHavingSumFiltersGroupsBelowThreshold()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = GroupedByUserWithHaving(
+            new FromExpression(SampleDatabase.Users.Entity),
+            UsersToOrdersInnerJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected = ExpectedUsersWithTotalAtLeast150(db);
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row => row.Uuid(SampleDatabase.Users.Id)!.Value),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void LeftJoinGroupByHavingSumExcludesUnmatchedNullGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = GroupedByUserWithHaving(
+            new FromExpression(SampleDatabase.Users.Entity),
+            UsersToOrdersLeftJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected = ExpectedUsersWithTotalAtLeast150(db);
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row => row.Uuid(SampleDatabase.Users.Id)!.Value),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void RightJoinGroupByHavingSumExcludesUnmatchedNullGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = GroupedByUserWithHaving(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            OrdersToUsersRightJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected = ExpectedUsersWithTotalAtLeast150(db);
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row => row.Uuid(SampleDatabase.Users.Id)!.Value),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void FullJoinGroupByHavingSumExcludesUnmatchedNullGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = GroupedByUserWithHaving(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            OrdersToUsersFullJoin()
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected = ExpectedUsersWithTotalAtLeast150(db);
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row => row.Uuid(SampleDatabase.Users.Id)!.Value),
+        ];
+
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new `Joins/JoinPipelineCombo*` matrix that layers the full
downstream pipeline (WHERE -> GROUP BY -> HAVING -> ORDER BY -> DISTINCT
-> pagination) on top of each `JoinType` (Inner, Left, Right, Full), per
issue #156. 28 new tests across three files:

- `Joins/JoinPipelineWhereHavingTests.cs` - `each*` WHERE filtering a
  joined-side column per join type (proving unmatched/padded rows drop
  out via 3VL, not just real mismatches); GROUP BY + count/sum per user
  for RIGHT/FULL (extending `OuterJoinAggregationTests`, which only
  covers LEFT); GROUP BY + HAVING(sum) per join type, where the
  unmatched-side NULL group is excluded the same way a real
  below-threshold group is.
- `Joins/JoinPipelineOrderDistinctPaginationTests.cs` - ORDER BY a
  joined numeric column with the ratified NULLS-last rule (both
  ascending and descending), ORDER BY an aggregate alias in group mode
  on top of an outer join, DISTINCT collapsing join fan-out including
  unmatched/padded rows (extending `Select/DistinctOverJoinTests`, which
  is INNER-only), DISTINCT on a joined string column showing the
  ratified `""` padding value show up as its own distinct entry, and
  ORDER BY + pagination windowing over joined rows per join type.
- `Joins/JoinPipelineFullStackTests.cs` - every clause composed in one
  query (join -> where -> group -> having -> order -> distinct ->
  paginate) per join type, plus two cross-schema (`audit.logins`)
  variants for breadth.

All expectations are computed independently from
`db.UserRows`/`db.OrderRows`/`db.LoginRows` using LINQ
`GroupJoin`/`SelectMany`+`DefaultIfEmpty` (or plain filters, where the
join is effectively an inner join) to mirror SQL result-set semantics,
per the issue's overriding principle - never derived from or bent to
match the translator's output.

## Findings

No divergences from SQL-correct expectations were found - every test
passed against the existing translator on the first run, so **no
`KnownGap` skips were needed** and there are no candidate bugs to
report from this matrix. This corroborates the semantics already
ratified in `Semantics/README.md` (outer-join NULL extension, NULLS-last
ordering, empty-group aggregates) under join-type x pipeline
combinations that weren't previously exercised together.

## Test plan

- [x] `dotnet build --no-restore -warnaserror`
- [x] `dotnet format --verify-no-changes`
- [x] `dotnet test --no-build --verbosity normal` (526 total, 525 passed,
      1 pre-existing skip, 0 failed)

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)