### PR TITLE
Add aggregate x each-expression-argument combination matrix to Aggregates suite

### DIFF
--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/AggregateOverExpressionComboTemporalTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/AggregateOverExpressionComboTemporalTests.cs
@@ -1,0 +1,745 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Date;
+using PureQL.CSharp.Model.Aggregates.DateTime;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.Aggregates.Time;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.EachDateArithmetics;
+using PureQL.CSharp.Model.EachDateTimeArithmetics;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.EachTimeArithmetics;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Aggregates;
+
+// Matrix of aggregate (numeric sum/avg/count, temporal min/max) over
+// temporal each-expression arguments (eachDateDiffDays/eachTimeDiffSeconds/
+// eachDateTimeDiffSeconds and eachDateAddDays/eachTimeAddSeconds/
+// eachDateTimeAddSeconds), across group-key types (uuid/string/bool/number)
+// and whole-set, plus HAVING and the temporal-average fail-fast. Numeric
+// each-arithmetic combos live in AggregateOverExpressionComboTests.cs. Every
+// expected value is computed independently in LINQ over the ground-truth
+// record lists; none of the fields used here (signup_date, placed_on,
+// placed_at, shift_start) carry NULLs in the fixture, so every diff/add is
+// always defined.
+[Trait("Clause", "Aggregate")]
+[Trait("Feature", "AggregateOverExpressionCombo")]
+public sealed class AggregateOverExpressionComboTemporalTests
+{
+    private static Join OrdersToUsersJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Users.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    // ===== each-temporal-diff arguments (return NumberArrayReturning) =====
+
+    private static NumberArrayReturning PlacedOnMinusSignupDate()
+    {
+        return new NumberArrayReturning(
+            new EachDateDiffDays(
+                new DateArrayReturning(
+                    new DateField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.PlacedOn)
+                ),
+                new DateArrayReturning(
+                    new DateField(SampleDatabase.Users.Entity, SampleDatabase.Users.SignupDate)
+                )
+            )
+        );
+    }
+
+    private static NumberArrayReturning ShiftStartMinusOrigin(TimeOnly origin)
+    {
+        return new NumberArrayReturning(
+            new EachTimeDiffSeconds(
+                new TimeArrayReturning(
+                    new TimeField(SampleDatabase.Users.Entity, SampleDatabase.Users.ShiftStart)
+                ),
+                new TimeReturning(new TimeScalar(origin))
+            )
+        );
+    }
+
+    private static NumberArrayReturning PlacedAtMinusLastLogin()
+    {
+        return new NumberArrayReturning(
+            new EachDateTimeDiffSeconds(
+                new DateTimeArrayReturning(
+                    new DateTimeField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.PlacedAt)
+                ),
+                new DateTimeArrayReturning(
+                    new DateTimeField(SampleDatabase.Users.Entity, SampleDatabase.Users.LastLogin)
+                )
+            )
+        );
+    }
+
+    // ===== each-temporal-add arguments =====
+
+    private static DateArrayReturning SignupDatePlusDays(double days)
+    {
+        return new DateArrayReturning(
+            new EachDateAddDays(
+                new DateArrayReturning(
+                    new DateField(SampleDatabase.Users.Entity, SampleDatabase.Users.SignupDate)
+                ),
+                new NumberReturning(new NumberScalar(days))
+            )
+        );
+    }
+
+    private static TimeArrayReturning ShiftStartPlusSeconds(double seconds)
+    {
+        return new TimeArrayReturning(
+            new EachTimeAddSeconds(
+                new TimeArrayReturning(
+                    new TimeField(SampleDatabase.Users.Entity, SampleDatabase.Users.ShiftStart)
+                ),
+                new NumberReturning(new NumberScalar(seconds))
+            )
+        );
+    }
+
+    private static DateTimeArrayReturning PlacedAtPlusSeconds(double seconds)
+    {
+        return new DateTimeArrayReturning(
+            new EachDateTimeAddSeconds(
+                new DateTimeArrayReturning(
+                    new DateTimeField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.PlacedAt)
+                ),
+                new NumberReturning(new NumberScalar(seconds))
+            )
+        );
+    }
+
+    // ===== select / group-by builders =====
+
+    private static SelectExpression NumberAggregateSelect(
+        NumberAggregate aggregate,
+        string alias
+    )
+    {
+        return new SelectExpression(
+            new SingleValueReturning(new NumberReturning(aggregate)),
+            alias
+        );
+    }
+
+    private static SelectExpression DateAggregateSelect(DateAggregate aggregate, string alias)
+    {
+        return new SelectExpression(
+            new SingleValueReturning(new DateReturning(aggregate)),
+            alias
+        );
+    }
+
+    private static SelectExpression TimeAggregateSelect(TimeAggregate aggregate, string alias)
+    {
+        return new SelectExpression(
+            new SingleValueReturning(new TimeReturning(aggregate)),
+            alias
+        );
+    }
+
+    private static SelectExpression DateTimeAggregateSelect(
+        DateTimeAggregate aggregate,
+        string alias
+    )
+    {
+        return new SelectExpression(
+            new SingleValueReturning(new DateTimeReturning(aggregate)),
+            alias
+        );
+    }
+
+    private static NumberReturning MaxOf(NumberArrayReturning argument)
+    {
+        return new NumberReturning(new NumberAggregate(new MaxNumber(argument)));
+    }
+
+    private static SelectExpression CountSelect(NumberArrayReturning argument, string alias)
+    {
+        return new SelectExpression(
+            new SingleValueReturning(
+                new NumberReturning(new Count(new ArrayReturning(argument)))
+            ),
+            alias
+        );
+    }
+
+    private static SelectExpression UuidGroupKeySelect(string entity, string field)
+    {
+        return new SelectExpression(
+            new ArrayReturning(new UuidArrayReturning(new UuidField(entity, field)))
+        );
+    }
+
+    private static SelectExpression StringGroupKeySelect(string entity, string field)
+    {
+        return new SelectExpression(
+            new ArrayReturning(new StringArrayReturning(new StringField(entity, field)))
+        );
+    }
+
+    private static SelectExpression BoolGroupKeySelect(string entity, string field)
+    {
+        return new SelectExpression(
+            new ArrayReturning(new BooleanArrayReturning(new BooleanField(entity, field)))
+        );
+    }
+
+    private static SelectExpression NumberGroupKeySelect(string entity, string field)
+    {
+        return new SelectExpression(
+            new ArrayReturning(new NumberArrayReturning(new NumberField(entity, field)))
+        );
+    }
+
+    private static Field UuidGroupKeyField(string entity, string field)
+    {
+        return new Field(new UuidField(entity, field));
+    }
+
+    private static Field StringGroupKeyField(string entity, string field)
+    {
+        return new Field(new StringField(entity, field));
+    }
+
+    private static Field BoolGroupKeyField(string entity, string field)
+    {
+        return new Field(new BooleanField(entity, field));
+    }
+
+    // ===== E: numeric aggregates over each-temporal-diff =====
+
+    [Fact]
+    public void SumOfEachDateDiffDaysGroupedByOrderUserIdComputesTotalSpanDays()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                NumberAggregateSelect(
+                    new NumberAggregate(new SumNumber(PlacedOnMinusSignupDate())),
+                    "totalSpanDays"
+                ),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = (
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select new
+            {
+                order.OrderUserId,
+                Span = (double)(order.PlacedOn.DayNumber - user.SignupDate.DayNumber),
+            }
+        )
+            .GroupBy(x => x.OrderUserId)
+            .ToDictionary(g => g.Key, g => g.Sum(x => x.Span));
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("totalSpanDays")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void AverageOfEachDateDiffDaysGroupedByOrderStatusComputesMeanSpanDays()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                StringGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Status),
+                NumberAggregateSelect(
+                    new NumberAggregate(new AverageNumber(PlacedOnMinusSignupDate())),
+                    "meanSpanDays"
+                ),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [StringGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Status)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<string, double> expected = (
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select new
+            {
+                order.OrderStatus,
+                Span = (double)(order.PlacedOn.DayNumber - user.SignupDate.DayNumber),
+            }
+        )
+            .GroupBy(x => x.OrderStatus)
+            .ToDictionary(g => g.Key, g => g.Average(x => x.Span));
+
+        Dictionary<string, double> actual = result.Rows.ToDictionary(
+            row => row[SampleDatabase.Orders.Status]!,
+            row => row.Double("meanSpanDays")!.Value
+        );
+
+        Assert.Equal(3, expected.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MinAndMaxOfEachDateDiffDaysGroupedByUserActiveBoundSpanDays()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                BoolGroupKeySelect(SampleDatabase.Users.Entity, SampleDatabase.Users.Active),
+                NumberAggregateSelect(
+                    new NumberAggregate(new MinNumber(PlacedOnMinusSignupDate())),
+                    "minSpanDays"
+                ),
+                NumberAggregateSelect(
+                    new NumberAggregate(new MaxNumber(PlacedOnMinusSignupDate())),
+                    "maxSpanDays"
+                ),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [BoolGroupKeyField(SampleDatabase.Users.Entity, SampleDatabase.Users.Active)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        IReadOnlyList<(bool Active, double Span)> spans =
+        [
+            .. from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select (
+                user.UserActive,
+                Span: (double)(order.PlacedOn.DayNumber - user.SignupDate.DayNumber)
+            ),
+        ];
+
+        Dictionary<bool, double> expectedMin = spans
+            .GroupBy(x => x.Active)
+            .ToDictionary(g => g.Key, g => g.Min(x => x.Span));
+
+        Dictionary<bool, double> expectedMax = spans
+            .GroupBy(x => x.Active)
+            .ToDictionary(g => g.Key, g => g.Max(x => x.Span));
+
+        Dictionary<bool, double> actualMin = result.Rows.ToDictionary(
+            row => row.Bool(SampleDatabase.Users.Active)!.Value,
+            row => row.Double("minSpanDays")!.Value
+        );
+
+        Dictionary<bool, double> actualMax = result.Rows.ToDictionary(
+            row => row.Bool(SampleDatabase.Users.Active)!.Value,
+            row => row.Double("maxSpanDays")!.Value
+        );
+
+        Assert.Equal(expectedMin, actualMin);
+        Assert.Equal(expectedMax, actualMax);
+    }
+
+    [Fact]
+    public void CountOfEachDateDiffDaysGroupedByUserAgeCountsDefinedSpans()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                NumberGroupKeySelect(SampleDatabase.Users.Entity, SampleDatabase.Users.Age),
+                CountSelect(PlacedOnMinusSignupDate(), "spanCount"),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [new Field(new NumberField(SampleDatabase.Users.Entity, SampleDatabase.Users.Age))],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<double, double> expected = (
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select user.UserAge
+        )
+            .GroupBy(age => age)
+            .ToDictionary(g => g.Key, g => (double)g.Count());
+
+        Dictionary<double, double> actual = result.Rows.ToDictionary(
+            row => row.Double(SampleDatabase.Users.Age)!.Value,
+            row => row.Double("spanCount")!.Value
+        );
+
+        // Ann and Cara share age 30: their four combined orders land in one
+        // group, so this pins count-over-each on a merged multi-user group.
+        Assert.Equal(4, expected[30]);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void SumOfEachTimeDiffSecondsWholeSetComputesTotalShiftGap()
+    {
+        SampleDatabase db = new SampleDatabase();
+        TimeOnly origin = new TimeOnly(8, 0, 0);
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                NumberAggregateSelect(
+                    new NumberAggregate(new SumNumber(ShiftStartMinusOrigin(origin))),
+                    "totalGapSeconds"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double expected = db.UserRows.Sum(user => (user.ShiftStart - origin).TotalSeconds);
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expected, result.Row(0).Double("totalGapSeconds"));
+    }
+
+    [Fact]
+    public void AverageOfEachDateTimeDiffSecondsGroupedByOrderUserIdComputesMeanGapSeconds()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                NumberAggregateSelect(
+                    new NumberAggregate(new AverageNumber(PlacedAtMinusLastLogin())),
+                    "meanGapSeconds"
+                ),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = (
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select new
+            {
+                order.OrderUserId,
+                Gap = (order.PlacedAt - user.LastLogin).TotalSeconds,
+            }
+        )
+            .GroupBy(x => x.OrderUserId)
+            .ToDictionary(g => g.Key, g => g.Average(x => x.Gap));
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("meanGapSeconds")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    // ===== F: temporal min/max over each-temporal-add =====
+
+    [Fact]
+    public void MaxOfEachDateAddDaysGroupedByUserActiveFindsLatestProjectedDate()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                BoolGroupKeySelect(SampleDatabase.Users.Entity, SampleDatabase.Users.Active),
+                DateAggregateSelect(
+                    new DateAggregate(new MaxDate(SignupDatePlusDays(30))),
+                    "latestProjectedDate"
+                ),
+            ],
+            where: null,
+            join: null,
+            [BoolGroupKeyField(SampleDatabase.Users.Entity, SampleDatabase.Users.Active)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<bool, DateOnly> expected = db.UserRows
+            .GroupBy(user => user.UserActive)
+            .ToDictionary(g => g.Key, g => g.Max(user => user.SignupDate.AddDays(30)));
+
+        Dictionary<bool, DateOnly> actual = result.Rows.ToDictionary(
+            row => row.Bool(SampleDatabase.Users.Active)!.Value,
+            row => row.Date("latestProjectedDate")!.Value
+        );
+
+        Assert.Equal(2, expected.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MinOfEachDateAddDaysGroupedByOrderStatusFindsEarliestProjectedDate()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                StringGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Status),
+                DateAggregateSelect(
+                    new DateAggregate(new MinDate(SignupDatePlusDays(30))),
+                    "earliestProjectedDate"
+                ),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [StringGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Status)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<string, DateOnly> expected = (
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select new { order.OrderStatus, Projected = user.SignupDate.AddDays(30) }
+        )
+            .GroupBy(x => x.OrderStatus)
+            .ToDictionary(g => g.Key, g => g.Min(x => x.Projected));
+
+        Dictionary<string, DateOnly> actual = result.Rows.ToDictionary(
+            row => row[SampleDatabase.Orders.Status]!,
+            row => row.Date("earliestProjectedDate")!.Value
+        );
+
+        Assert.Equal(3, expected.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MaxOfEachTimeAddSecondsWholeSetFindsLatestProjectedTime()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                TimeAggregateSelect(
+                    new TimeAggregate(new MaxTime(ShiftStartPlusSeconds(3600))),
+                    "latestProjectedTime"
+                ),
+            ]
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        TimeOnly expected = db.UserRows.Max(user =>
+            user.ShiftStart.Add(TimeSpan.FromSeconds(3600))
+        );
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expected, result.Row(0).Time("latestProjectedTime"));
+    }
+
+    [Fact]
+    public void MinOfEachDateTimeAddSecondsGroupedByOrderUserIdFindsEarliestProjectedInstant()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                DateTimeAggregateSelect(
+                    new DateTimeAggregate(new MinDateTime(PlacedAtPlusSeconds(1800))),
+                    "earliestProjectedInstant"
+                ),
+            ],
+            where: null,
+            join: null,
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, DateTime> expected = db.OrderRows
+            .GroupBy(order => order.OrderUserId)
+            .ToDictionary(
+                g => g.Key,
+                g => g.Min(order => order.PlacedAt.AddSeconds(1800))
+            );
+
+        Dictionary<Guid, DateTime> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.DateTime("earliestProjectedInstant")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    // ===== G: HAVING on a temporal-diff aggregate =====
+
+    [Fact]
+    public void HavingMaxOfEachDateDiffDaysComparisonKeepsQualifyingGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                NumberAggregateSelect(
+                    new NumberAggregate(new MaxNumber(PlacedOnMinusSignupDate())),
+                    "maxSpanDays"
+                ),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.GreaterThan,
+                        MaxOf(PlacedOnMinusSignupDate()),
+                        new NumberReturning(new NumberScalar(1500))
+                    )
+                )
+            ),
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. (
+                from order in db.OrderRows
+                join user in db.UserRows on order.OrderUserId equals user.UserId
+                select new
+                {
+                    order.OrderUserId,
+                    Span = (double)(order.PlacedOn.DayNumber - user.SignupDate.DayNumber),
+                }
+            )
+                .GroupBy(x => x.OrderUserId)
+                .Where(g => g.Max(x => x.Span) > 1500)
+                .Select(g => g.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row => row.Uuid(SampleDatabase.Orders.UserId)!.Value),
+        ];
+
+        Assert.Equal(2, expected.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    // ===== H: temporal average is unimplemented (fail-fast, not a
+    // KnownGap - CLAUDE.md documents this as an intentional execution gap
+    // with undefined rounding semantics) =====
+
+    [Fact]
+    public void AverageOfEachDateAddDaysThrowsNotSupportedForTemporalAverage()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Users.Entity),
+            [
+                DateAggregateSelect(
+                    new DateAggregate(new AverageDate(SignupDatePlusDays(30))),
+                    "meanProjectedDate"
+                ),
+            ]
+        );
+
+        _ = Assert.Throws<NotSupportedException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+}

--- a/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/AggregateOverExpressionComboTests.cs
+++ b/src/Tests/Pure.RelationalSchema.Storage.PureQL.Projection.Tests/Aggregates/AggregateOverExpressionComboTests.cs
@@ -1,0 +1,1096 @@
+using Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Data;
+using PureQL.CSharp.Model;
+using PureQL.CSharp.Model.Aggregates;
+using PureQL.CSharp.Model.Aggregates.Numeric;
+using PureQL.CSharp.Model.ArrayReturnings;
+using PureQL.CSharp.Model.Comparisons;
+using PureQL.CSharp.Model.EachArithmetics;
+using PureQL.CSharp.Model.EachEqualities;
+using PureQL.CSharp.Model.Equalities;
+using PureQL.CSharp.Model.Fields;
+using PureQL.CSharp.Model.Returnings;
+using PureQL.CSharp.Model.Scalars;
+
+namespace Pure.RelationalSchema.Storage.PureQL.Projection.Tests.Aggregates;
+
+// Matrix of aggregate (count / numeric sum-avg-min-max) over each-arithmetic
+// (eachAdd/eachSubtract/eachMultiply/eachDivide) arguments, across varied
+// group-key types (uuid/string/bool/number) and whole-set, plus HAVING on
+// the computed aggregate. Temporal each-expression combos live in
+// AggregateOverExpressionComboTemporalTests.cs. Every expected value is
+// computed independently in LINQ over the ground-truth record lists under
+// SQL aggregate rules: aggregates ignore NULL inputs, COUNT ignores NULL
+// results the same as any other aggregate, and an all-NULL/empty group folds
+// to NULL (COUNT folds to 0).
+//
+// eachDivide by zero: WhereExpressionBuilder.DivideDoubles raises
+// DivideByZeroException for a zero divisor (matching SQL division-by-zero
+// semantics), not a silent NULL - pinned for WHERE by
+// Errors/NegativePathTests.EachDivideByZeroFailsFast. This suite pins the
+// identical fail-fast behaviour when the same expression is folded by an
+// aggregate instead of filtered by WHERE.
+[Trait("Clause", "Aggregate")]
+[Trait("Feature", "AggregateOverExpressionCombo")]
+public sealed class AggregateOverExpressionComboTests
+{
+    // ===== Join chains =====
+
+    private static IReadOnlyList<Join> OrdersToItemsToProductsJoin()
+    {
+        return
+        [
+            new Join(
+                JoinType.Inner,
+                SampleDatabase.OrderItems.Entity,
+                new BooleanArrayReturning(
+                    new EachEquality(
+                        new EachUuidEquality(
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.OrderItems.Entity,
+                                    SampleDatabase.OrderItems.OrderId
+                                )
+                            ),
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.Orders.Entity,
+                                    SampleDatabase.Orders.Id
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+            new Join(
+                JoinType.Inner,
+                SampleDatabase.Products.Entity,
+                new BooleanArrayReturning(
+                    new EachEquality(
+                        new EachUuidEquality(
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.OrderItems.Entity,
+                                    SampleDatabase.OrderItems.ProductId
+                                )
+                            ),
+                            new UuidArrayReturning(
+                                new UuidField(
+                                    SampleDatabase.Products.Entity,
+                                    SampleDatabase.Products.Id
+                                )
+                            )
+                        )
+                    )
+                )
+            ),
+        ];
+    }
+
+    private static Join OrdersToUsersJoin()
+    {
+        return new Join(
+            JoinType.Inner,
+            SampleDatabase.Users.Entity,
+            new BooleanArrayReturning(
+                new EachEquality(
+                    new EachUuidEquality(
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.UserId
+                            )
+                        ),
+                        new UuidArrayReturning(
+                            new UuidField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Id
+                            )
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    // ===== each-arithmetic arguments =====
+
+    private static NumberArrayReturning QtyTimesPrice()
+    {
+        return new NumberArrayReturning(
+            new EachArithmetic(
+                new EachMultiply(
+                    [
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.OrderItems.Entity,
+                                SampleDatabase.OrderItems.Qty
+                            )
+                        ),
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Products.Entity,
+                                SampleDatabase.Products.Price
+                            )
+                        ),
+                    ]
+                )
+            )
+        );
+    }
+
+    private static NumberArrayReturning TotalPlusAge()
+    {
+        return new NumberArrayReturning(
+            new EachArithmetic(
+                new EachAdd(
+                    [
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        ),
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Age
+                            )
+                        ),
+                    ]
+                )
+            )
+        );
+    }
+
+    private static NumberArrayReturning TotalMinusAge()
+    {
+        return new NumberArrayReturning(
+            new EachArithmetic(
+                new EachSubtract(
+                    [
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        ),
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Age
+                            )
+                        ),
+                    ]
+                )
+            )
+        );
+    }
+
+    private static NumberArrayReturning TotalDividedByScore()
+    {
+        return new NumberArrayReturning(
+            new EachArithmetic(
+                new EachDivide(
+                    [
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        ),
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Users.Entity,
+                                SampleDatabase.Users.Score
+                            )
+                        ),
+                    ]
+                )
+            )
+        );
+    }
+
+    // Denominator is zero exactly for orders whose total is 100.50 (orders
+    // 101 and 106), to pin the aggregate-context divide-by-zero fail-fast.
+    private static NumberArrayReturning TotalDividedByTotalMinusThreshold()
+    {
+        return new NumberArrayReturning(
+            new EachArithmetic(
+                new EachDivide(
+                    [
+                        new NumberArrayReturning(
+                            new NumberField(
+                                SampleDatabase.Orders.Entity,
+                                SampleDatabase.Orders.Total
+                            )
+                        ),
+                        new NumberArrayReturning(
+                            new EachArithmetic(
+                                new EachSubtract(
+                                    [
+                                        new NumberArrayReturning(
+                                            new NumberField(
+                                                SampleDatabase.Orders.Entity,
+                                                SampleDatabase.Orders.Total
+                                            )
+                                        ),
+                                        new NumberReturning(new NumberScalar(100.50)),
+                                    ]
+                                )
+                            )
+                        ),
+                    ]
+                )
+            )
+        );
+    }
+
+    // ===== select / group-by builders =====
+
+    private static SelectExpression AggregateSelect(
+        NumberAggregate aggregate,
+        string alias
+    )
+    {
+        return new SelectExpression(
+            new SingleValueReturning(new NumberReturning(aggregate)),
+            alias
+        );
+    }
+
+    private static NumberReturning SumOf(NumberArrayReturning argument)
+    {
+        return new NumberReturning(new NumberAggregate(new SumNumber(argument)));
+    }
+
+    private static NumberReturning AverageOf(NumberArrayReturning argument)
+    {
+        return new NumberReturning(new NumberAggregate(new AverageNumber(argument)));
+    }
+
+    private static NumberReturning CountOf(NumberArrayReturning argument)
+    {
+        return new NumberReturning(new Count(new ArrayReturning(argument)));
+    }
+
+    private static SelectExpression CountSelect(NumberArrayReturning argument, string alias)
+    {
+        return new SelectExpression(new SingleValueReturning(CountOf(argument)), alias);
+    }
+
+    private static SelectExpression UuidGroupKeySelect(string entity, string field)
+    {
+        return new SelectExpression(
+            new ArrayReturning(new UuidArrayReturning(new UuidField(entity, field)))
+        );
+    }
+
+    private static SelectExpression StringGroupKeySelect(string entity, string field)
+    {
+        return new SelectExpression(
+            new ArrayReturning(new StringArrayReturning(new StringField(entity, field)))
+        );
+    }
+
+    private static SelectExpression BoolGroupKeySelect(string entity, string field)
+    {
+        return new SelectExpression(
+            new ArrayReturning(new BooleanArrayReturning(new BooleanField(entity, field)))
+        );
+    }
+
+    private static SelectExpression NumberGroupKeySelect(string entity, string field)
+    {
+        return new SelectExpression(
+            new ArrayReturning(new NumberArrayReturning(new NumberField(entity, field)))
+        );
+    }
+
+    private static Field UuidGroupKeyField(string entity, string field)
+    {
+        return new Field(new UuidField(entity, field));
+    }
+
+    private static Field StringGroupKeyField(string entity, string field)
+    {
+        return new Field(new StringField(entity, field));
+    }
+
+    private static Field BoolGroupKeyField(string entity, string field)
+    {
+        return new Field(new BooleanField(entity, field));
+    }
+
+    // ===== SQL NULL-aware folds over a nullable-double sequence =====
+
+    private static double? SqlSum(IEnumerable<double?> values)
+    {
+        List<double> defined = [.. values.Where(v => v.HasValue).Select(v => v!.Value)];
+        return defined.Count == 0 ? null : defined.Sum();
+    }
+
+    private static double SqlCount(IEnumerable<double?> values)
+    {
+        return values.Count(v => v.HasValue);
+    }
+
+    private static double? SqlMin(IEnumerable<double?> values)
+    {
+        List<double> defined = [.. values.Where(v => v.HasValue).Select(v => v!.Value)];
+        return defined.Count == 0 ? null : defined.Min();
+    }
+
+    private static double? SqlMax(IEnumerable<double?> values)
+    {
+        List<double> defined = [.. values.Where(v => v.HasValue).Select(v => v!.Value)];
+        return defined.Count == 0 ? null : defined.Max();
+    }
+
+    // ===== A: eachMultiply(item_qty, product_price), grouped by uuid =====
+
+    [Fact]
+    public void SumOfEachMultiplyGroupedByOrderUserIdComputesRevenuePerUser()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                AggregateSelect(new NumberAggregate(new SumNumber(QtyTimesPrice())), "revenue"),
+            ],
+            where: null,
+            OrdersToItemsToProductsJoin(),
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = (
+            from item in db.OrderItemRows
+            join order in db.OrderRows on item.ItemOrderId equals order.OrderId
+            join product in db.ProductRows on item.ItemProductId equals product.ProductId
+            select new { order.OrderUserId, Value = item.ItemQty * product.ProductPrice }
+        )
+            .GroupBy(x => x.OrderUserId)
+            .ToDictionary(g => g.Key, g => g.Sum(x => x.Value));
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("revenue")!.Value
+        );
+
+        Assert.NotEmpty(expected);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void AverageOfEachMultiplyGroupedByOrderUserIdComputesMeanLineValue()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                AggregateSelect(
+                    new NumberAggregate(new AverageNumber(QtyTimesPrice())),
+                    "meanLineValue"
+                ),
+            ],
+            where: null,
+            OrdersToItemsToProductsJoin(),
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = (
+            from item in db.OrderItemRows
+            join order in db.OrderRows on item.ItemOrderId equals order.OrderId
+            join product in db.ProductRows on item.ItemProductId equals product.ProductId
+            select new { order.OrderUserId, Value = item.ItemQty * product.ProductPrice }
+        )
+            .GroupBy(x => x.OrderUserId)
+            .ToDictionary(g => g.Key, g => g.Average(x => x.Value));
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("meanLineValue")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MinAndMaxOfEachMultiplyGroupedByOrderUserIdBoundLineValues()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                AggregateSelect(
+                    new NumberAggregate(new MinNumber(QtyTimesPrice())),
+                    "minLineValue"
+                ),
+                AggregateSelect(
+                    new NumberAggregate(new MaxNumber(QtyTimesPrice())),
+                    "maxLineValue"
+                ),
+            ],
+            where: null,
+            OrdersToItemsToProductsJoin(),
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        IReadOnlyList<(Guid UserId, double Value)> lineValues =
+        [
+            .. from item in db.OrderItemRows
+            join order in db.OrderRows on item.ItemOrderId equals order.OrderId
+            join product in db.ProductRows on item.ItemProductId equals product.ProductId
+            select (order.OrderUserId, Value: item.ItemQty * product.ProductPrice),
+        ];
+
+        Dictionary<Guid, double> expectedMin = lineValues
+            .GroupBy(x => x.UserId)
+            .ToDictionary(g => g.Key, g => g.Min(x => x.Value));
+
+        Dictionary<Guid, double> expectedMax = lineValues
+            .GroupBy(x => x.UserId)
+            .ToDictionary(g => g.Key, g => g.Max(x => x.Value));
+
+        Dictionary<Guid, double> actualMin = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("minLineValue")!.Value
+        );
+
+        Dictionary<Guid, double> actualMax = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("maxLineValue")!.Value
+        );
+
+        Assert.Equal(expectedMin, actualMin);
+        Assert.Equal(expectedMax, actualMax);
+    }
+
+    [Fact]
+    public void CountOfEachMultiplyGroupedByOrderUserIdCountsLineItems()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                CountSelect(QtyTimesPrice(), "lineCount"),
+            ],
+            where: null,
+            OrdersToItemsToProductsJoin(),
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<Guid, double> expected = (
+            from item in db.OrderItemRows
+            join order in db.OrderRows on item.ItemOrderId equals order.OrderId
+            join product in db.ProductRows on item.ItemProductId equals product.ProductId
+            select order.OrderUserId
+        )
+            .GroupBy(id => id)
+            .ToDictionary(g => g.Key, g => (double)g.Count());
+
+        Dictionary<Guid, double> actual = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("lineCount")!.Value
+        );
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void WholeSetSumOfEachMultiplyComputesTotalRevenue()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [AggregateSelect(new NumberAggregate(new SumNumber(QtyTimesPrice())), "revenue")],
+            where: null,
+            OrdersToItemsToProductsJoin(),
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double expected = (
+            from item in db.OrderItemRows
+            join order in db.OrderRows on item.ItemOrderId equals order.OrderId
+            join product in db.ProductRows on item.ItemProductId equals product.ProductId
+            select item.ItemQty * product.ProductPrice
+        ).Sum();
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expected, result.Row(0).Double("revenue"));
+    }
+
+    // ===== B: eachAdd/eachSubtract(order_total, user_age), grouped by
+    // bool/number/string =====
+
+    [Fact]
+    public void SumOfEachAddGroupedByUserActiveComputesTotalPlusAge()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                BoolGroupKeySelect(SampleDatabase.Users.Entity, SampleDatabase.Users.Active),
+                AggregateSelect(
+                    new NumberAggregate(new SumNumber(TotalPlusAge())),
+                    "totalPlusAge"
+                ),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [BoolGroupKeyField(SampleDatabase.Users.Entity, SampleDatabase.Users.Active)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<bool, double> expected = (
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select new { user.UserActive, Value = order.OrderTotal + user.UserAge }
+        )
+            .GroupBy(x => x.UserActive)
+            .ToDictionary(g => g.Key, g => g.Sum(x => x.Value));
+
+        Dictionary<bool, double> actual = result.Rows.ToDictionary(
+            row => row.Bool(SampleDatabase.Users.Active)!.Value,
+            row => row.Double("totalPlusAge")!.Value
+        );
+
+        Assert.Equal(2, expected.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void AverageOfEachAddGroupedByUserAgeComputesMeanTotalPlusAge()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                NumberGroupKeySelect(SampleDatabase.Users.Entity, SampleDatabase.Users.Age),
+                AggregateSelect(
+                    new NumberAggregate(new AverageNumber(TotalPlusAge())),
+                    "meanTotalPlusAge"
+                ),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [new Field(new NumberField(SampleDatabase.Users.Entity, SampleDatabase.Users.Age))],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<double, double> expected = (
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select new { user.UserAge, Value = order.OrderTotal + user.UserAge }
+        )
+            .GroupBy(x => x.UserAge)
+            .ToDictionary(g => g.Key, g => g.Average(x => x.Value));
+
+        Dictionary<double, double> actual = result.Rows.ToDictionary(
+            row => row.Double(SampleDatabase.Users.Age)!.Value,
+            row => row.Double("meanTotalPlusAge")!.Value
+        );
+
+        // Ann and Cara share age 30, so this group merges two users' orders -
+        // a real multi-user group, not merely one row per group.
+        Assert.Contains(expected, pair => pair.Key == 30);
+        Assert.Equal(3, expected.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void MinAndMaxOfEachSubtractGroupedByUserActiveBoundDifference()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                BoolGroupKeySelect(SampleDatabase.Users.Entity, SampleDatabase.Users.Active),
+                AggregateSelect(new NumberAggregate(new MinNumber(TotalMinusAge())), "minDiff"),
+                AggregateSelect(new NumberAggregate(new MaxNumber(TotalMinusAge())), "maxDiff"),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [BoolGroupKeyField(SampleDatabase.Users.Entity, SampleDatabase.Users.Active)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        IReadOnlyList<(bool Active, double Value)> diffs =
+        [
+            .. from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select (user.UserActive, Value: order.OrderTotal - user.UserAge),
+        ];
+
+        Dictionary<bool, double> expectedMin = diffs
+            .GroupBy(x => x.Active)
+            .ToDictionary(g => g.Key, g => g.Min(x => x.Value));
+
+        Dictionary<bool, double> expectedMax = diffs
+            .GroupBy(x => x.Active)
+            .ToDictionary(g => g.Key, g => g.Max(x => x.Value));
+
+        Dictionary<bool, double> actualMin = result.Rows.ToDictionary(
+            row => row.Bool(SampleDatabase.Users.Active)!.Value,
+            row => row.Double("minDiff")!.Value
+        );
+
+        Dictionary<bool, double> actualMax = result.Rows.ToDictionary(
+            row => row.Bool(SampleDatabase.Users.Active)!.Value,
+            row => row.Double("maxDiff")!.Value
+        );
+
+        Assert.Equal(expectedMin, actualMin);
+        Assert.Equal(expectedMax, actualMax);
+    }
+
+    [Fact]
+    public void CountOfEachSubtractGroupedByOrderStatusCountsRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                StringGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Status),
+                CountSelect(TotalMinusAge(), "diffCount"),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [StringGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.Status)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        Dictionary<string, double> expected = db.OrderRows
+            .GroupBy(order => order.OrderStatus)
+            .ToDictionary(g => g.Key, g => (double)g.Count());
+
+        Dictionary<string, double> actual = result.Rows.ToDictionary(
+            row => row[SampleDatabase.Orders.Status]!,
+            row => row.Double("diffCount")!.Value
+        );
+
+        Assert.Equal(3, expected.Count);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void WholeSetAverageOfEachSubtractComputesOverallMeanDifference()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [AggregateSelect(new NumberAggregate(new AverageNumber(TotalMinusAge())), "meanDiff")],
+            where: null,
+            [OrdersToUsersJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        double expected = (
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select order.OrderTotal - user.UserAge
+        ).Average();
+
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expected, result.Row(0).Double("meanDiff"));
+    }
+
+    // ===== C: eachDivide(order_total, user_score) - NULL exclusion and
+    // divide-by-zero fail-fast =====
+
+    [Fact]
+    public void SumAndCountOfEachDivideGroupedByOrderUserIdExcludeNullScoreRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                AggregateSelect(
+                    new NumberAggregate(new SumNumber(TotalDividedByScore())),
+                    "sumRatio"
+                ),
+                CountSelect(TotalDividedByScore(), "ratioCount"),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        IReadOnlyList<(Guid UserId, double? Ratio)> ratios =
+        [
+            .. from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select (
+                order.OrderUserId,
+                Ratio: user.Score.HasValue ? order.OrderTotal / user.Score.Value : (double?)null
+            ),
+        ];
+
+        Dictionary<Guid, double?> expectedSum = ratios
+            .GroupBy(x => x.UserId)
+            .ToDictionary(g => g.Key, g => SqlSum(g.Select(x => x.Ratio)));
+
+        Dictionary<Guid, double> expectedCount = ratios
+            .GroupBy(x => x.UserId)
+            .ToDictionary(g => g.Key, g => SqlCount(g.Select(x => x.Ratio)));
+
+        Dictionary<Guid, double?> actualSum = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("sumRatio")
+        );
+
+        Dictionary<Guid, double> actualCount = result.Rows.ToDictionary(
+            row => row.Uuid(SampleDatabase.Orders.UserId)!.Value,
+            row => row.Double("ratioCount")!.Value
+        );
+
+        // Bob and Dan each have exactly one order and a NULL score, so their
+        // group folds to an all-NULL sum (SQL SUM over no defined rows) and
+        // a zero count - not merely "smaller", but genuinely empty.
+        Assert.Contains(expectedSum, pair => pair.Value is null);
+        Assert.Contains(expectedCount, pair => pair.Value == 0);
+        Assert.Equal(expectedSum, actualSum);
+        Assert.Equal(expectedCount, actualCount);
+    }
+
+    [Fact]
+    public void MinOfEachDivideWholeSetExcludesNullScoreRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [AggregateSelect(new NumberAggregate(new MinNumber(TotalDividedByScore())), "minRatio")],
+            where: null,
+            [OrdersToUsersJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        IEnumerable<double?> ratios =
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select user.Score.HasValue ? order.OrderTotal / user.Score.Value : (double?)null;
+
+        double? expected = SqlMin(ratios);
+
+        _ = Assert.NotNull(expected);
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expected, result.Row(0).Double("minRatio"));
+    }
+
+    [Fact]
+    public void MaxOfEachDivideWholeSetExcludesNullScoreRows()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [AggregateSelect(new NumberAggregate(new MaxNumber(TotalDividedByScore())), "maxRatio")],
+            where: null,
+            [OrdersToUsersJoin()],
+            groupBy: null,
+            having: null,
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        IEnumerable<double?> ratios =
+            from order in db.OrderRows
+            join user in db.UserRows on order.OrderUserId equals user.UserId
+            select user.Score.HasValue ? order.OrderTotal / user.Score.Value : (double?)null;
+
+        double? expected = SqlMax(ratios);
+
+        _ = Assert.NotNull(expected);
+        Assert.Equal(1, result.Count);
+        Assert.Equal(expected, result.Row(0).Double("maxRatio"));
+    }
+
+    [Fact]
+    public void AggregateOverEachDivideByZeroDenominatorThrowsDivideByZeroException()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                AggregateSelect(
+                    new NumberAggregate(new SumNumber(TotalDividedByTotalMinusThreshold())),
+                    "sumRatio"
+                ),
+            ]
+        );
+
+        _ = Assert.Throws<DivideByZeroException>(() => new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        ));
+    }
+
+    // ===== D: HAVING on the computed aggregate =====
+
+    [Fact]
+    public void HavingSumOfEachMultiplyGreaterThanKeepsQualifyingOrders()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                AggregateSelect(new NumberAggregate(new SumNumber(QtyTimesPrice())), "revenue"),
+            ],
+            where: null,
+            OrdersToItemsToProductsJoin(),
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.GreaterThan,
+                        SumOf(QtyTimesPrice()),
+                        new NumberReturning(new NumberScalar(25))
+                    )
+                )
+            ),
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. (
+                from item in db.OrderItemRows
+                join order in db.OrderRows on item.ItemOrderId equals order.OrderId
+                join product in db.ProductRows
+                    on item.ItemProductId equals product.ProductId
+                select new { order.OrderUserId, Value = item.ItemQty * product.ProductPrice }
+            )
+                .GroupBy(x => x.OrderUserId)
+                .Where(g => g.Sum(x => x.Value) > 25)
+                .Select(g => g.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row => row.Uuid(SampleDatabase.Orders.UserId)!.Value),
+        ];
+
+        Assert.NotEmpty(expected);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingAverageOfEachSubtractLessThanOrEqualKeepsQualifyingGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                BoolGroupKeySelect(SampleDatabase.Users.Entity, SampleDatabase.Users.Active),
+                AggregateSelect(
+                    new NumberAggregate(new AverageNumber(TotalMinusAge())),
+                    "meanDiff"
+                ),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [BoolGroupKeyField(SampleDatabase.Users.Entity, SampleDatabase.Users.Active)],
+            new BooleanReturning(
+                new Comparison(
+                    new NumberComparison(
+                        ComparisonOperator.LessThanOrEqual,
+                        AverageOf(TotalMinusAge()),
+                        new NumberReturning(new NumberScalar(100))
+                    )
+                )
+            ),
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<bool> expected =
+        [
+            .. (
+                from order in db.OrderRows
+                join user in db.UserRows on order.OrderUserId equals user.UserId
+                select new { user.UserActive, Value = order.OrderTotal - user.UserAge }
+            )
+                .GroupBy(x => x.UserActive)
+                .Where(g => g.Average(x => x.Value) <= 100)
+                .Select(g => g.Key),
+        ];
+
+        HashSet<bool> actual =
+        [
+            .. result.Rows.Select(row => row.Bool(SampleDatabase.Users.Active)!.Value),
+        ];
+
+        _ = Assert.Single(expected);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void HavingCountOfEachDivideEqualToZeroKeepsOnlyAllNullGroups()
+    {
+        SampleDatabase db = new SampleDatabase();
+
+        Query query = new Query(
+            new FromExpression(SampleDatabase.Orders.Entity),
+            [
+                UuidGroupKeySelect(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId),
+                CountSelect(TotalDividedByScore(), "ratioCount"),
+            ],
+            where: null,
+            [OrdersToUsersJoin()],
+            [UuidGroupKeyField(SampleDatabase.Orders.Entity, SampleDatabase.Orders.UserId)],
+            new BooleanReturning(
+                new Equality(
+                    new SingleValueEquality(
+                        new NumberEquality(
+                            CountOf(TotalDividedByScore()),
+                            new NumberReturning(new NumberScalar(0))
+                        )
+                    )
+                )
+            ),
+            orderBy: null,
+            pagination: null
+        );
+
+        ProjectionResult result = new ProjectionResult(
+            new PureQLProjection(db.Datasets, query)
+        );
+
+        HashSet<Guid> expected =
+        [
+            .. (
+                from order in db.OrderRows
+                join user in db.UserRows on order.OrderUserId equals user.UserId
+                select (
+                    order.OrderUserId,
+                    Ratio: user.Score.HasValue
+                        ? order.OrderTotal / user.Score.Value
+                        : (double?)null
+                )
+            )
+                .GroupBy(x => x.OrderUserId)
+                .Where(g => SqlCount(g.Select(x => x.Ratio)) == 0)
+                .Select(g => g.Key),
+        ];
+
+        HashSet<Guid> actual =
+        [
+            .. result.Rows.Select(row => row.Uuid(SampleDatabase.Orders.UserId)!.Value),
+        ];
+
+        Assert.Equal(2, expected.Count);
+        Assert.Equal(expected, actual);
+    }
+}


### PR DESCRIPTION
## Summary

- New file `Aggregates/AggregateOverExpressionComboTests.cs` (17 tests): numeric aggregates (sum/avg/min/max/count) over `eachMultiply`/`eachAdd`/`eachSubtract`/`eachDivide`, grouped by uuid (`order_user_id`), string (`order_status`), bool (`user_active`), number (`user_age`), and whole-set, plus HAVING on the computed aggregate.
- New file `Aggregates/AggregateOverExpressionComboTemporalTests.cs` (12 tests): numeric aggregates over `eachDateDiffDays`/`eachTimeDiffSeconds`/`eachDateTimeDiffSeconds`, temporal min/max over `eachDateAddDays`/`eachTimeAddSeconds`/`eachDateTimeAddSeconds`, grouped across the same four key types and whole-set, plus one HAVING test and one fail-fast test for the documented temporal-average gap.
- 29 tests total, all green. Every expected value is computed independently in LINQ over the ground-truth record lists (`SampleDatabase`), never derived from the translator under test.

## Notable finding (not a KnownGap - already-intentional, already-tested behaviour)

The issue text (and this repo's `Semantics/README.md`) describes `eachDivide` by zero as returning `NULL` for that row, excluded from the fold. That description is stale: commit `9f47af2` ("Fail fast on missing columns, type mismatches, malformed cell text, and eachDivide by zero", 2026-07-22) deliberately changed `WhereExpressionBuilder.DivideDoubles` to raise `DivideByZeroException` instead, matching SQL division-by-zero semantics, and this is already pinned for the WHERE clause by `Errors/NegativePathTests.EachDivideByZeroFailsFast`.

This suite adds `AggregateOverExpressionComboTests.AggregateOverEachDivideByZeroDenominatorThrowsDivideByZeroException`, which pins the identical fail-fast behaviour when the same expression is folded by an aggregate (`SUM`) instead of filtered by `WHERE` - `AggregateEvaluator.Fold` reaches the same `DivideDoubles` call via `WhereExpressionBuilder.BuildNumberSelector`. No `KnownGap` skip was needed here since the actual behaviour is correct, intentional, and consistent with existing coverage - not a divergence from SQL semantics.

Separately, `eachDivide` with a NULL *operand* (as opposed to a zero denominator) still folds per standard SQL NULL-propagation - covered by `SumAndCountOfEachDivideGroupedByOrderUserIdExcludeNullScoreRows`, `MinOfEachDivideWholeSetExcludesNullScoreRows`, `MaxOfEachDivideWholeSetExcludesNullScoreRows`, and `HavingCountOfEachDivideEqualToZeroKeepsOnlyAllNullGroups` (an all-NULL group folds to `NULL`/count `0`, verified via HAVING).

## Verification

- `dotnet format --verify-no-changes` clean
- `dotnet build --no-restore -warnaserror`: 0 warnings, 0 errors
- `dotnet test --no-build --filter "Status!=KnownGap"`: 575/575 passed (29 new)

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)