### PR TITLE
Update package validation baseline to 0.1.0-preview.2.2.2

### DIFF
--- a/src/Pure.RelationalSchema.Storage.PureQL.Projection/Pure.RelationalSchema.Storage.PureQL.Projection.csproj
+++ b/src/Pure.RelationalSchema.Storage.PureQL.Projection/Pure.RelationalSchema.Storage.PureQL.Projection.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <IsAotCompatible>false</IsAotCompatible>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.1.0-preview.2.2.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.1.0-preview.2.2.2</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Pure.RelationalSchema.Storage.PureQL.Projection</PackageId>


### PR DESCRIPTION
Bump `PackageValidationBaselineVersion` from `0.1.0-preview.2.2.1` to `0.1.0-preview.2.2.2` following the successful publish of that version to NuGet.

Note: the coverage check is expected to be red — `main` currently sits at ~94.72% line coverage against the 95% gate introduced in #162 (a deliberate ratchet, satisfied once the pending fail-fast test coverage lands). This PR only changes the csproj baseline property; build, format, tests, and mutation gates should pass.